### PR TITLE
Capture timeouts

### DIFF
--- a/measurements/api/measurements.py
+++ b/measurements/api/measurements.py
@@ -10,7 +10,7 @@ import connexion
 import requests
 import lz4framed
 
-from sentry_sdk import configure_scope
+from sentry_sdk import configure_scope, capture_exception
 
 from flask import Blueprint, current_app, request, make_response
 from flask.json import jsonify
@@ -361,6 +361,7 @@ def list_measurements(
                 })
         except OperationalError as exc:
             if isinstance(exc.orig, QueryCanceledError):
+                capture_exception(exc)
                 raise QueryTimeoutError()
             raise exc
 

--- a/measurements/api/measurements.py
+++ b/measurements/api/measurements.py
@@ -361,7 +361,7 @@ def list_measurements(
                 })
         except OperationalError as exc:
             if isinstance(exc.orig, QueryCanceledError):
-                capture_exception(exc)
+                capture_exception(QueryTimeoutError())
                 raise QueryTimeoutError()
             raise exc
 


### PR DESCRIPTION
Now that timeouts are handled properly, they are not logged to sentry anymore.

This PR is about capturing the timeouts explicitly if we believe that is a useful thing to do.

We do run the risk of spamming sentry with too many exceptions, but maybe it's useful for us to optimise the database.