### PR TITLE
Legacy explr fix

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+# ooni-api 1.1.2 [2019-06-07]
+Fixes:
+
+* Bug in `/blockpage_count` and ordering
+
 # ooni-api 1.1.1 [2019-06-06]
 
 Changed:

--- a/measurements/__init__.py
+++ b/measurements/__init__.py
@@ -2,4 +2,4 @@ __author__ = "Open Observatory of Network Interference"
 __email__ = "contact@openobservatory.org"
 
 __license__ = "BSD 3 Clause"
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/measurements/api/private.py
+++ b/measurements/api/private.py
@@ -130,11 +130,13 @@ def api_private_countries():
     })
 
 # XXX Everything below here are ghetto hax to support legacy OONI Explorer
+two_months_ago = datetime.now() - relativedelta(months=2)
 @api_private_blueprint.route('/blockpages', methods=["GET"])
 def api_private_blockpages():
     probe_cc = request.args.get('probe_cc')
     if probe_cc is None:
         raise Exception('err')
+
 
     q = current_app.db_session.query(
         Report.report_id.label('report_id'),
@@ -149,6 +151,7 @@ def api_private_blockpages():
         Report.test_name == 'web_connectivity'
       ) \
      .filter(Report.probe_cc == probe_cc)
+     .filter(Report.test_start_time > two_months_ago)
 
     results = []
     for row in q:
@@ -183,6 +186,7 @@ def api_private_website_measurements():
         Report.test_name == 'web_connectivity'
       ) \
      .filter(Input.input.contains(input_))
+     .filter(Report.test_start_time > two_months_ago)
 
     results = []
     for row in q:

--- a/measurements/api/private.py
+++ b/measurements/api/private.py
@@ -130,7 +130,6 @@ def api_private_countries():
     })
 
 # XXX Everything below here are ghetto hax to support legacy OONI Explorer
-two_months_ago = datetime.now() - relativedelta(months=2)
 @api_private_blueprint.route('/blockpages', methods=["GET"])
 def api_private_blockpages():
     probe_cc = request.args.get('probe_cc')
@@ -150,8 +149,7 @@ def api_private_blockpages():
      .filter(
         Report.test_name == 'web_connectivity'
       ) \
-     .filter(Report.probe_cc == probe_cc)
-     .filter(Report.test_start_time > two_months_ago)
+     .filter(Report.probe_cc == probe_cc).limit(100)
 
     results = []
     for row in q:
@@ -185,8 +183,7 @@ def api_private_website_measurements():
      .filter(
         Report.test_name == 'web_connectivity'
       ) \
-     .filter(Input.input.contains(input_))
-     .filter(Report.test_start_time > two_months_ago)
+     .filter(Input.input.contains(input_)).limit(100)
 
     results = []
     for row in q:


### PR DESCRIPTION
We apply a limit of 100 on the private API endpoints required by the legacy explorer `/website_measurements` and `/blockpages` so that they are no longer unbound and the query performance should be a bit better.