### PR TITLE
No 1 day lag

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,9 @@
+# ooni-api 1.1.3 [2019-08-13]
+
+Changed:
+
+* Improvements to the performance of the legacy explorer endpoints
+
 # ooni-api 1.1.2 [2019-06-07]
 Fixes:
 

--- a/measurements/__init__.py
+++ b/measurements/__init__.py
@@ -2,4 +2,4 @@ __author__ = "Open Observatory of Network Interference"
 __email__ = "contact@openobservatory.org"
 
 __license__ = "BSD 3 Clause"
-__version__ = "1.1.2"
+__version__ = "1.1.3"

--- a/measurements/api/private.py
+++ b/measurements/api/private.py
@@ -301,7 +301,7 @@ def last_30days():
 def get_recent_network_coverage(probe_cc, test_groups):
     where_clause = [
         sql.text("test_day >= current_date - interval '31 day'"),
-        sql.text("test_day < current_date - interval '1 day'"),
+        sql.text("test_day < current_date"),
         sql.text("probe_cc = :probe_cc"),
     ]
     if test_groups is not None:
@@ -347,7 +347,7 @@ def get_recent_test_coverage(probe_cc):
         and_(
             sql.text("test_day >= (current_date - interval '31 day')"),
             # We exclude the last day to wait for the pipeline
-            sql.text("test_day < current_date - interval '1 day'"),
+            sql.text("test_day < current_date"),
             sql.text("probe_cc = :probe_cc"),
         )
     ).group_by(
@@ -460,7 +460,7 @@ LEFT OUTER JOIN
     JOIN input ON input.input_no = measurement.input_no
     JOIN report ON report.report_no = measurement.report_no
     WHERE test_start_time >= current_date - interval '31 day'
-    AND test_start_time < current_date - interval '1 day'
+    AND test_start_time < current_date
     AND probe_cc =  :probe_cc
     AND probe_asn = :probe_asn
     AND input.input = :input
@@ -660,7 +660,7 @@ def api_private_im_networks():
         and_(
             sql.text("test_day >= current_date - interval '31 day'"),
             # We exclude the last day to wait for the pipeline
-            sql.text("test_day < current_date - interval '1 day'"),
+            sql.text("test_day < current_date"),
             sql.text("probe_cc = :probe_cc"),
             or_(*test_names)
         )
@@ -722,7 +722,7 @@ LEFT OUTER JOIN
     AND test_name = :test_name
     AND probe_asn = :probe_asn
 	AND test_day >= current_date - interval '31 day'
-	AND test_day < current_date - interval '1 day'
+	AND test_day < current_date
 	GROUP BY test_day
 ) m
 ON d.test_day = m.test_day

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ooni-measurements",
-  "version": "1.0.6",
+  "version": "1.1.3",
   "license": "BSD-2-Clause",
   "dependencies": {
     "babel-core": "6.14.0",


### PR DESCRIPTION
Even if the pipeline ticks at 24h it's still bad to always put a lag of
24h because if the pipeline has just ticked it will ignore 23h worth of
fresh measurements.
