### PR TITLE
Add support for searching by domain

### DIFF
--- a/measurements/api/private.py
+++ b/measurements/api/private.py
@@ -134,7 +134,7 @@ def api_private_countries():
 def api_private_blockpages():
     probe_cc = request.args.get('probe_cc')
     if probe_cc is None:
-        raise Exception('err')
+        raise BadRequest('missing probe_cc')
 
 
     q = current_app.db_session.query(
@@ -169,7 +169,7 @@ def api_private_blockpages():
 def api_private_website_measurements():
     input_ = request.args.get('input')
     if input_ is None:
-        raise Exception('err')
+        raise BadRequest('missing input')
 
     q = current_app.db_session.query(
         Report.report_id.label('report_id'),
@@ -225,7 +225,7 @@ def api_private_blockpage_detected():
 def api_private_blockpage_count():
     probe_cc = request.args.get('probe_cc')
     if probe_cc is None:
-        raise Exception('missing probe_cc')
+        raise BadRequest('missing probe_cc')
 
     s = sql.text("""SELECT SUM(confirmed_count), SUM(msm_count), test_day
     FROM ooexpl_wc_confirmed
@@ -314,7 +314,7 @@ def get_recent_network_coverage(probe_cc, test_groups):
                 tg_names = TEST_GROUPS[tg]
                 tg_or += [sql.literal_column("test_name") == tg_name for tg_name in tg_names]
             except KeyError:
-                raise Exception('invalid test_group')
+                raise BadRequest('invalid test_group')
         where_clause.append(or_(*tg_or))
 
     s = select([
@@ -379,7 +379,7 @@ def get_recent_test_coverage(probe_cc):
 def api_private_test_coverage():
     probe_cc = request.args.get('probe_cc')
     if probe_cc is None or len(probe_cc) != 2:
-        raise Exception('missing probe_cc')
+        raise BadRequest('missing probe_cc')
 
     test_groups = request.args.get('test_groups')
     if test_groups is not None:
@@ -394,7 +394,7 @@ def api_private_test_coverage():
 def api_private_website_network_tests():
     probe_cc = request.args.get('probe_cc')
     if probe_cc is None or len(probe_cc) != 2:
-        raise Exception('missing probe_cc')
+        raise BadRequest('missing probe_cc')
 
     s = select([
         sql.text("COUNT(*)"),
@@ -434,11 +434,11 @@ def api_private_website_stats():
 
     probe_cc = request.args.get('probe_cc')
     if probe_cc is None or len(probe_cc) != 2:
-        raise Exception('missing probe_cc')
+        raise BadRequest('missing probe_cc')
 
     probe_asn = request.args.get('probe_asn')
     if probe_asn is None:
-        raise Exception('missing probe_asn')
+        raise BadRequest('missing probe_asn')
 
     s = sql.text("""SELECT
 d.test_day,
@@ -496,11 +496,11 @@ def api_private_website_test_urls():
 
     probe_cc = request.args.get('probe_cc')
     if probe_cc is None or len(probe_cc) != 2:
-        raise Exception('missing probe_cc')
+        raise BadRequest('missing probe_cc')
 
     probe_asn = request.args.get('probe_asn')
     if probe_asn is None:
-        raise Exception('missing probe_asn')
+        raise BadRequest('missing probe_asn')
 
     probe_asn = int(probe_asn.replace('AS', ''))
     where_clause = [
@@ -582,7 +582,7 @@ def api_private_website_test_urls():
 def api_private_vanilla_tor_stats():
     probe_cc = request.args.get('probe_cc')
     if probe_cc is None or len(probe_cc) != 2:
-        raise Exception('missing probe_cc')
+        raise BadRequest('missing probe_cc')
     s = sql.text("""SELECT
 	vt.probe_asn,
 	MAX(vt.measurement_start_time) as last_tested,
@@ -651,7 +651,7 @@ GROUP BY 1;""")
 def api_private_im_networks():
     probe_cc = request.args.get('probe_cc')
     if probe_cc is None or len(probe_cc) != 2:
-        raise Exception('missing probe_cc')
+        raise BadRequest('missing probe_cc')
 
     test_names = [sql.literal_column("test_name") == tg_name for tg_name in TEST_GROUPS['im']]
     s = select([
@@ -696,15 +696,15 @@ def api_private_im_networks():
 def api_private_im_stats():
     test_name = request.args.get('test_name')
     if not test_name or test_name not in TEST_GROUPS['im']:
-        raise Exception('invalid test_name')
+        raise BadRequest('invalid test_name')
 
     probe_cc = request.args.get('probe_cc')
     if probe_cc is None or len(probe_cc) != 2:
-        raise Exception('missing probe_cc')
+        raise BadRequest('missing probe_cc')
 
     probe_asn = request.args.get('probe_asn')
     if probe_asn is None:
-        raise Exception('missing probe_asn')
+        raise BadRequest('missing probe_asn')
     probe_asn = int(probe_asn.replace('AS', ''))
 
     s = sql.text("""SELECT COALESCE(count, 0), d.test_day
@@ -755,7 +755,7 @@ ORDER BY test_day;""")
 def api_private_network_stats():
     probe_cc = request.args.get('probe_cc')
     if probe_cc is None or len(probe_cc) != 2:
-        raise Exception('missing probe_cc')
+        raise BadRequest('missing probe_cc')
 
     limit = int(request.args.get('limit', 10))
     if limit <= 0:
@@ -829,7 +829,7 @@ def api_private_network_stats():
 def api_private_country_overview():
     probe_cc = request.args.get('probe_cc')
     if probe_cc is None or len(probe_cc) != 2:
-        raise Exception('missing probe_cc')
+        raise BadRequest('missing probe_cc')
 
     row = current_app.db_session.execute(
         select([

--- a/measurements/openapi/measurements.yml
+++ b/measurements/openapi/measurements.yml
@@ -26,6 +26,11 @@ paths:
           type: string
           minLength: 3 # `input` is handled by pg_trgm
           description: The input (for example a URL or IP address) to search measurements for
+        - name: domain
+          in: query
+          type: string
+          minLength: 3
+          description: The domain to search measurements for
         - name: probe_cc
           in: query
           type: string


### PR DESCRIPTION
This implements: https://github.com/ooni/api/issues/52

On some test cases using `domain` instead of `input` for filtering the target domain name we get a 100x performance gain.

See:

**Before**:
```
EXPLAIN ANALYZE
SELECT measurement.input_no AS m_input_no, measurement.measurement_start_time AS measurement_start_time, measurement.msm_no AS msm_no, measurement.report_no AS m_report_no, coalesce(measurement.anomaly, false) AS anomaly, coalesce(measurement.confirmed, false) AS confirmed, coalesce(measurement.msm_failure, false) AS msm_failure, measurement.exc AS exc, measurement.residual_no AS residual_no, report.report_id AS report_id, report.probe_cc AS probe_cc, report.probe_asn AS probe_asn, report.test_name AS test_name, report.report_no AS report_no, coalesce(input.input, NULL) AS input
FROM measurement JOIN report ON report.report_no = measurement.report_no JOIN input ON measurement.input_no = input.input_no
WHERE input.input LIKE '%%google.com%%' AND report.test_name = 'web_connectivity' ORDER BY test_start_time desc
 LIMIT 100 OFFSET 0;


Limit  (cost=6008720.69..6008720.94 rows=100 width=181) (actual time=482516.887..482517.126 rows=100 loops=1)
  ->  Sort  (cost=6008720.69..6008727.23 rows=2613 width=181) (actual time=482516.885..482516.963 rows=100 loops=1)
        Sort Key: report.test_start_time DESC
        Sort Method: top-N heapsort  Memory: 51kB
        ->  Nested Loop  (cost=1.00..6008620.83 rows=2613 width=181) (actual time=0.759..476700.235 rows=3008623 loops=1)
              ->  Nested Loop  (cost=0.57..5958840.44 rows=27056 width=73) (actual time=0.742..434003.226 rows=3235992 loops=1)
                    ->  Seq Scan on input  (cost=0.00..30516.26 rows=157 width=25) (actual time=0.000..553.824 rows=4202 loops=1)
                          Filter: (input ~~ '%%google.com%%'::text)
                          Rows Removed by Filter: 1560758
                    ->  Index Scan using measurement_v2_input_no_idx on measurement  (cost=0.57..37278.54 rows=48149 width=52) (actual time=0.139..101.491 rows=770 loops=4202)
                          Index Cond: (input_no = input.input_no)
              ->  Index Scan using report_pkey on report  (cost=0.43..1.83 rows=1 width=97) (actual time=0.008..0.009 rows=1 loops=3235992)
                    Index Cond: (report_no = measurement.report_no)
                    Filter: (test_name = 'web_connectivity'::ootest)
                    Rows Removed by Filter: 0
Planning time: 0.289 ms
Execution time: 482517.241 ms

```

**After**:
```
EXPLAIN ANALYZE
SELECT measurement.input_no AS m_input_no, measurement.measurement_start_time AS measurement_start_time, measurement.msm_no AS msm_no, measurement.report_no AS m_report_no, coalesce(measurement.anomaly, false) AS anomaly, coalesce(measurement.confirmed, false) AS confirmed, coalesce(measurement.msm_failure, false) AS msm_failure, measurement.exc AS exc, measurement.residual_no AS residual_no, report.report_id AS report_id, report.probe_cc AS probe_cc, report.probe_asn AS probe_asn, report.test_name AS test_name, report.report_no AS report_no, coalesce(input.input, NULL) AS input
FROM measurement JOIN report ON report.report_no = measurement.report_no JOIN input ON measurement.input_no = input.input_no
WHERE input.input SIMILAR TO '(https://|http://)google.com%%' AND report.test_name = 'web_connectivity' ORDER BY test_start_time desc
 LIMIT 100 OFFSET 0

Limit  (cost=6008720.69..6008720.94 rows=100 width=181) (actual time=2275.895..2276.143 rows=100 loops=1)
  ->  Sort  (cost=6008720.69..6008727.23 rows=2613 width=181) (actual time=2275.892..2275.983 rows=100 loops=1)
        Sort Key: report.test_start_time DESC
        Sort Method: top-N heapsort  Memory: 53kB
        ->  Nested Loop  (cost=1.00..6008620.83 rows=2613 width=181) (actual time=16.287..2273.799 rows=1263 loops=1)
              ->  Nested Loop  (cost=0.57..5958840.44 rows=27056 width=73) (actual time=16.270..2187.494 rows=13452 loops=1)
                    ->  Seq Scan on input  (cost=0.00..30516.26 rows=157 width=25) (actual time=16.241..2131.136 rows=154 loops=1)
                          Filter: (input ~ '^(?:(?:https://|http://)google\.com.*.*)$'::text)
                          Rows Removed by Filter: 1564806
                    ->  Index Scan using measurement_v2_input_no_idx on measurement  (cost=0.57..37278.54 rows=48149 width=52) (actual time=0.010..0.210 rows=87 loops=154)
                          Index Cond: (input_no = input.input_no)
              ->  Index Scan using report_pkey on report  (cost=0.43..1.83 rows=1 width=97) (actual time=0.004..0.005 rows=0 loops=13452)
                    Index Cond: (report_no = measurement.report_no)
                    Filter: (test_name = 'web_connectivity'::ootest)
                    Rows Removed by Filter: 1
Planning time: 0.793 ms
Execution time: 2276.324 ms
```
