### PR TITLE
Optimize the api_private_stats endpoints

### DIFF
--- a/measurements/api/private.py
+++ b/measurements/api/private.py
@@ -918,4 +918,7 @@ def api_private_global_overview():
         'country_count': row[0],
         'network_count': row[1],
         'measurement_count': row[2],
+        'networks_by_month': api_private_stats_by_month('COUNT(DISTINCT probe_asn)'),
+        'countries_by_month': api_private_stats_by_month('COUNT(DISTINCT probe_cc)'),
+        'measurements_by_month': api_private_stats_by_month('SUM(count)')
     })

--- a/measurements/api/private.py
+++ b/measurements/api/private.py
@@ -59,15 +59,15 @@ def api_private_stats_by_month(orm_stat):
         'date': (bkt + relativedelta(months=+1, days=-1)).strftime("%Y-%m-%d"),
         'value': value,
     } for bkt, value in sorted(r)]
-    return jsonify(result)
+    return result
 
 @api_private_blueprint.route('/asn_by_month')
 def api_private_asn_by_month():
-    return api_private_stats_by_month('COUNT(DISTINCT probe_asn)')
+    return jsonify(api_private_stats_by_month('COUNT(DISTINCT probe_asn)'))
 
 @api_private_blueprint.route('/countries_by_month')
 def api_private_countries_by_month():
-    return api_private_stats_by_month('COUNT(DISTINCT probe_cc)')
+    return jsonify(api_private_stats_by_month('COUNT(DISTINCT probe_cc)'))
 
 @api_private_blueprint.route('/runs_by_month')
 def api_private_runs_by_month():

--- a/measurements/api/private.py
+++ b/measurements/api/private.py
@@ -917,7 +917,12 @@ def api_private_global_overview():
     return jsonify({
         'country_count': row[0],
         'network_count': row[1],
-        'measurement_count': row[2],
+        'measurement_count': row[2]
+    })
+
+@api_private_blueprint.route('/global_overview_by_month', methods=["GET"])
+def api_private_global_by_month():
+    return jsonify({
         'networks_by_month': api_private_stats_by_month('COUNT(DISTINCT probe_asn)'),
         'countries_by_month': api_private_stats_by_month('COUNT(DISTINCT probe_cc)'),
         'measurements_by_month': api_private_stats_by_month('SUM(count)')


### PR DESCRIPTION
This changes a little bit the meaning of the stats queries as it considers the time in which a measurement is uploaded instead of the time in which it was run.

I think this is pretty consistent with what we present in the UIs and it's significantly faster to do it this way so I think it's ok.

The performance gain for these queries is in the order of 10-100x.