### PR TITLE
Faster domain filter

### DIFF
--- a/measurements/api/measurements.py
+++ b/measurements/api/measurements.py
@@ -16,7 +16,8 @@ from flask import Blueprint, current_app, request, make_response
 from flask.json import jsonify
 from werkzeug.exceptions import HTTPException, BadRequest
 
-from sqlalchemy import func, or_, and_, false, true, text
+from sqlalchemy.dialects import postgresql
+from sqlalchemy import func, or_, and_, false, true, text, select, sql, column
 from sqlalchemy.orm import lazyload
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.exc import OperationalError
@@ -200,31 +201,33 @@ def get_measurement(measurement_id, download=None):
                 'attachment', filename=filename)
     return response
 
-def input_filter(q, input_, domain, test_name):
+def input_cte(input_, domain, test_name):
     if input_ and domain:
         raise BadRequest("Must pick either domain or input")
 
     if not input_ and not domain:
-        q = q.outerjoin(Input, Measurement.input_no == Input.input_no)
+        return None
 
+    where_or = []
     if input_:
-        q = q.join(Input, Measurement.input_no == Input.input_no)\
-             .filter(Input.input.like('%{}%'.format(input_)))
+        where_or.append(
+            text('input.input LIKE :i').bindparams(i='%{}%'.format(input_)),
+        )
 
     if domain:
-        q = q.join(Input, Measurement.input_no == Input.input_no)
         domain_filter = '{}%'.format(domain)
-        web_filter = '(https://|http://){}'.format(domain_filter)
-        if test_name not in ['web_connectivity', 'http_requests']:
-            q = q.filter(or_(
-                text('input.input SIMILAR TO :web_filter').bindparams(web_filter=web_filter),
-                text('input.input SIMILAR TO :domain_filter').bindparams(domain_filter=domain_filter)
-            ))
-        else:
-            q = q.filter(
-                text('input.input SIMILAR TO :web_filter').bindparams(web_filter=web_filter)
-            )
-    return q
+        where_or.append(text('input.input LIKE :domain_filter').bindparams(domain_filter=domain_filter))
+        if test_name in [None, 'web_connectivity', 'http_requests']:
+            where_or.append(text('input.input LIKE :http_filter').bindparams(http_filter='http://{}'.format(domain_filter)))
+            where_or.append(text('input.input LIKE :https_filter').bindparams(https_filter='https://{}'.format(domain_filter)))
+
+    url_q = select([
+        column("input").label('input'),
+        column("input_no").label('input_no'),
+    ]).where(
+        or_(*where_or)
+    ).select_from(sql.table('input'))
+    return url_q.cte('input_cte')
 
 def list_measurements(
         report_id=None,
@@ -284,14 +287,12 @@ def list_measurements(
     if order.lower() not in ('asc', 'desc'):
         raise BadRequest("Invalid order")
 
-
     c_anomaly = func.coalesce(Measurement.anomaly, false())\
                     .label('anomaly')
     c_confirmed = func.coalesce(Measurement.confirmed, false())\
                     .label('confirmed')
     c_msm_failure = func.coalesce(Measurement.msm_failure, false())\
                     .label('msm_failure')
-
     cols = [
         Measurement.input_no.label('m_input_no'),
         Measurement.measurement_start_time.label('measurement_start_time'),
@@ -310,13 +311,23 @@ def list_measurements(
         Report.probe_asn.label('probe_asn'),
         Report.test_name.label('test_name'),
         Report.report_no.label('report_no'),
-        func.coalesce(Input.input, None).label('input')
     ]
 
-    q = current_app.db_session.query(*cols)\
-            .join(Report, Report.report_no == Measurement.report_no)
+    cte = input_cte(input_=input_, domain=domain, test_name=test_name)
 
-    q = input_filter(q, input_=input_, domain=domain, test_name=test_name)
+    if cte is not None:
+        cols.append(cte)
+    else:
+        cols.append(func.coalesce(Input.input, None).label('input'))
+
+    q = current_app.db_session.query(*cols)
+    if cte is not None:
+        q = q.join(cte, sql.text('input_cte.input_no = measurement.input_no'))
+    else:
+        q = q.outerjoin(Input, Measurement.input_no == Input.input_no)
+    q = q.join(Report, Report.report_no == Measurement.report_no)
+
+    q.join(Report, Report.report_no == Measurement.report_no)
     if report_id:
         q = q.filter(Report.report_id == report_id)
     if probe_cc:
@@ -356,8 +367,9 @@ def list_measurements(
     iter_start_time = time.time()
     results = []
 
+    query_str = str(q.statement.compile(dialect=postgresql.dialect()))
     with configure_scope() as scope:
-        scope.set_extra("sql_query", str(q))
+        scope.set_extra("sql_query", query_str)
 
         try:
             for row in q:

--- a/measurements/api/measurements.py
+++ b/measurements/api/measurements.py
@@ -17,7 +17,7 @@ from flask.json import jsonify
 from werkzeug.exceptions import HTTPException, BadRequest
 
 from sqlalchemy.dialects import postgresql
-from sqlalchemy import func, or_, and_, false, true, text, select, sql, column
+from sqlalchemy import func, or_, and_, false, text, select, sql, column
 from sqlalchemy.orm import lazyload
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.exc import OperationalError

--- a/measurements/app.py
+++ b/measurements/app.py
@@ -72,6 +72,12 @@ def init_app(app):
             continue
         app.logger.debug("{}: {}".format(key, app.config[key]))
 
+    if app.config['APP_ENV'] == 'production':
+        sentry_sdk.init(
+            dsn="https://dcb077b34ac140d58a7c37609cea0cf9@sentry.io/1367288",
+            integrations=[FlaskIntegration()]
+        )
+
     md = Misaka(fenced_code=True)
     md.init_app(app)
 
@@ -85,11 +91,6 @@ def create_app(*args, **kw):
 
     if sys.version_info[0] < 3:
         raise RuntimeError("Python >= 3 is required")
-
-    sentry_sdk.init(
-        dsn="https://dcb077b34ac140d58a7c37609cea0cf9@sentry.io/1367288",
-        integrations=[FlaskIntegration()]
-    )
 
     app = Flask(__name__)
     app.json_encoder = FlaskJSONEncoder

--- a/measurements/database.py
+++ b/measurements/database.py
@@ -9,7 +9,6 @@ import time
 from sqlalchemy import event
 from sqlalchemy.engine import Engine
 
-from sqlalchemy.dialects import postgresql
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base

--- a/measurements/database.py
+++ b/measurements/database.py
@@ -9,6 +9,7 @@ import time
 from sqlalchemy import event
 from sqlalchemy.engine import Engine
 
+from sqlalchemy.dialects import postgresql
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
@@ -63,5 +64,5 @@ def init_query_logging(app):
         app.logger.debug("Total Time: %f", total_time)
 
         if total_time >= QUERY_TIME_THRESHOLD:
-            app.logger.warning("Query: %s", statement)
+            app.logger.warning("Query: %s %r", statement, parameters)
             app.logger.warning("Took too much time: %f", total_time)

--- a/tests/functional/test_smoke.py
+++ b/tests/functional/test_smoke.py
@@ -4,3 +4,6 @@ def test_api_smoke(client):
 
     response = client.get("/api/v1/measurements")
     assert response.status_code == 200
+
+    response = client.get("/api/v1/measurements?domain=ooni.io")
+    assert response.status_code == 200


### PR DESCRIPTION
Query time for an example query has gone from 537,136.721 ms
to 146.392 ms.

This improvement is achieved by creating a CTE and using it to hint the
query planner as to how to do the cross table JOIN.