### PR TITLE
Fix #355

### DIFF
--- a/measurements/api/measurements.py
+++ b/measurements/api/measurements.py
@@ -539,6 +539,9 @@ def list_measurements(
         fpq = fpq.filter(Fastpath.test_name == test_name)
     if input_:
         fpq = fpq.filter(Fastpath.input == input_)
+    # TODO, we don't support filtering by confirmed filter in the fastpath, so
+    # we exclude all the fastpath measurements when filtering by confirmed is
+    # set
     if confirmed is not None:
         fpq = fpq.filter(False)
     if anomaly is not None:

--- a/measurements/api/measurements.py
+++ b/measurements/api/measurements.py
@@ -17,7 +17,7 @@ from werkzeug.exceptions import HTTPException, BadRequest
 
 from sqlalchemy.dialects import postgresql
 from sqlalchemy import func, or_, and_, false, text, select, sql, column
-from sqlalchemy import String, cast
+from sqlalchemy import String, cast, Float
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.exc import OperationalError
 from psycopg2.extensions import QueryCanceledError
@@ -501,7 +501,9 @@ def list_measurements(
         Fastpath.measurement_start_time.label("measurement_start_time"),
         func.concat(FASTPATH_MSM_ID_PREFIX, Fastpath.tid).label("measurement_id"),
         func.coalesce(0).label("m_report_no"),
-        func.coalesce(false()).label("anomaly"),
+        func.coalesce(
+            (cast(cast(Fastpath.scores["blocking_general"], String), Float) > 0.5)
+        ).label("anomaly"),
         func.coalesce(false()).label("confirmed"),
         func.coalesce(false()).label("msm_failure"),
         cast(Fastpath.scores.label("scores"), String),
@@ -537,7 +539,12 @@ def list_measurements(
         fpq = fpq.filter(Fastpath.test_name == test_name)
     if input_:
         fpq = fpq.filter(Fastpath.input == input_)
-
+    if confirmed is not None:
+        fpq = fpq.filter(False)
+    if anomaly is not None:
+        fpq = fpq.filter(
+            cast(cast(Fastpath.scores["blocking_general"], String), Float) > 0.5
+        )
     if order_by is not None:
         q = q.order_by(text("{} {}".format(order_by, order)))
     q = q.limit(limit).offset(offset)

--- a/tests/integ/test_integration.py
+++ b/tests/integ/test_integration.py
@@ -180,7 +180,7 @@ def api(client, subpath):
 def test_redirects_and_rate_limit(client):
     # Simulate a forwarded client with a different ipaddr
     # In production the API sits behind Nginx
-    headers={"X-Real-IP": "1.2.3.4"}
+    headers = {"X-Real-IP": "1.2.3.4"}
     limit = 400 - 1
     resp = client.get("/stats", headers=headers)
     assert resp.status_code == 301
@@ -202,7 +202,7 @@ def test_redirects_and_rate_limit(client):
 
 def test_redirects_and_rate_limit_for_explorer(client):
     # Special ipaddr: no rate limiting. No header is set by the server
-    headers={"X-Real-IP": "37.218.242.149"}
+    headers = {"X-Real-IP": "37.218.242.149"}
     resp = client.get("/stats", headers=headers)
     assert resp.status_code == 301
     assert "X-RateLimit-Remaining" not in resp.headers
@@ -407,3 +407,19 @@ def test_get_measurement_joined_multi(app, client, shared_rid_input_multi):
     for f in ("probe_asn", "probe_cc", "report_id", "input", "test_name"):
         # (measurement_start_time differs in the timezone letter)
         assert msm[f] == pick[f], "%r field: %r != %r" % (f, msm[f], pick[f])
+
+
+@pytest.mark.get_measurement
+def test_bug_355_confirmed(app, client):
+    p = "measurements?probe_cc=IQ&limit=50&confirmed=true"
+    response = api(client, p)
+    for r in response["results"]:
+        assert r["confirmed"] == True, r
+
+
+@pytest.mark.get_measurement
+def test_bug_355_anomaly(app, client):
+    p = "measurements?probe_cc=IQ&limit=50&anomaly=true"
+    response = api(client, p)
+    for r in response["results"]:
+        assert r["anomaly"] == True, r


### PR DESCRIPTION
Add filtering on confirmed and anomaly in list_measurements for fastpath.
This is meant to be temporary. I'll add anomaly and confirmed columns to the fastpath table and populate them to ease integration with the API, Explorer and manually run queries - for the time being.