### PR TITLE
Refactor list_measurements

### DIFF
--- a/measurements/api/measurements.py
+++ b/measurements/api/measurements.py
@@ -340,7 +340,7 @@ def list_measurements(
 ):
     """Search for measurements using only the database. Provide pagination.
     """
-    # FIXME: list_measurements and get_measurement will be simplified and
+    # TODO: list_measurements and get_measurement will be simplified and
     # made faster by OOID: https://github.com/ooni/pipeline/issues/48
 
     log = current_app.logger

--- a/measurements/api/measurements.py
+++ b/measurements/api/measurements.py
@@ -578,7 +578,7 @@ def list_measurements(
         s = s.order_by(text("{} {}".format(order_by, order)))
     s = s.limit(limit).offset(offset)
 
-    fpq = current_app.db_session.query(s, query_params)
+    fpq = current_app.db_session.execute(s, query_params)
     try:
         q = q.union(fpq)
     except:

--- a/measurements/api/measurements.py
+++ b/measurements/api/measurements.py
@@ -313,7 +313,7 @@ def list_measurements(
     since=None,
     until=None,
     since_index=None,
-    order_by="test_start_time",
+    order_by="measurement_start_time",
     order="desc",
     offset=0,
     limit=100,

--- a/measurements/api/measurements.py
+++ b/measurements/api/measurements.py
@@ -267,22 +267,6 @@ def get_measurement(measurement_id, download=None):
     return response
 
 
-def log_query(log, q):
-    import sqlparse  # debdeps: python3-sqlparse
-
-    if "Select" in repr(type(q)):  # UGLY
-        log.info("\n--- query ---\n\n%s\n\n-------------", q)
-        return
-
-    sql = str(
-        q.statement.compile(
-            dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
-        )
-    )
-    sql = sqlparse.format(sql, reindent=True, keyword_case="upper")
-    log.info("\n--- query ---\n\n%s\n\n-------------", sql)
-
-
 def _merge_two_results(a, b):
     """Merge 2 measurements. Collect useful fields from traditional pipeline
     and fastpath

--- a/measurements/api/measurements.py
+++ b/measurements/api/measurements.py
@@ -530,7 +530,11 @@ def list_measurements(
 
     # We runs SELECTs on the measurement-report (mr) tables and faspath independently
     # from each other and then merge them.
-    # An ORDER BY + LIMIT on "limit+offset" is applied in each SELECT as a speedup.
+    # The FULL OUTER JOIN query is using LIMIT and OFFSET based on the
+    # list_measurements arguments. To speed up the two nested queries,
+    # an ORDER BY + LIMIT on "limit+offset" is applied in each of them to trim
+    # away rows that would be removed anyways by the outer query.
+    #
     # During a merge we can find that a measurement is:
     # - only in fastpath:       get_measurement will pick the JSON msmt from the fastpath host
     # - in both selects:        pick `scores` from fastpath and the msmt from the can

--- a/measurements/models.py
+++ b/measurements/models.py
@@ -172,23 +172,3 @@ class Software(Base):
     software_version = Column(String)
 
     reports = relationship("Report", back_populates="software")
-
-
-class Fastpath(Base):
-    __tablename__ = "fastpath"
-    tid = Column(String, primary_key=True)  # nn
-    report_id = Column(String)  # nn
-    input = Column(String)
-    probe_cc = Column(String(2), nullable=False)
-    probe_asn = Column(Integer, nullable=False)
-    test_name = Column(String)
-    test_start_time = Column(DateTime, nullable=False)
-    measurement_start_time = Column(DateTime)
-    filename = Column(String)
-    scores = Column(JSON)
-
-class Domain_input(Base):
-    __tablename__ = "domain_input"
-    domain = Column(String, primary_key=True)
-    input = Column(String)
-    input_no = Column(Integer)

--- a/measurements/models.py
+++ b/measurements/models.py
@@ -186,3 +186,9 @@ class Fastpath(Base):
     measurement_start_time = Column(DateTime)
     filename = Column(String)
     scores = Column(JSON)
+
+class Domain_input(Base):
+    __tablename__ = "domain_input"
+    domain = Column(String, primary_key=True)
+    input = Column(String)
+    input_no = Column(Integer)

--- a/tests/integ/test_integration.py
+++ b/tests/integ/test_integration.py
@@ -310,6 +310,47 @@ def test_list_measurements_probe_asn(app, client):
         assert r["probe_asn"] == "AS3352"
 
 
+def test_list_measurements_failure_true_pipeline(app, client):
+    p = "measurements?failure=true&since=2019-12-8&until=2019-12-11&limit=50"
+    response = api(client, p)
+    assert len(response["results"]) == 50
+    for r in response["results"]:
+        assert r["failure"] == True
+
+    assert r["measurement_id"] == "temp-id-364655453"
+
+
+def test_list_measurements_failure_false_pipeline(app, client):
+    p = "measurements?failure=false&since=2019-12-8&until=2019-12-11&limit=50"
+    response = api(client, p)
+    assert len(response["results"]) == 50
+    for r in response["results"]:
+        assert r["failure"] == False, r
+
+    assert r["measurement_id"] == "temp-id-364945591"
+
+
+@pytest.mark.skip(reason="no way of currently testing this")
+def test_list_measurements_failure_true_fastpath(app, client):
+    since = datetime.utcnow().date()
+    until = since + timedelta(days=1)
+    p = f"measurements?failure=true&since={since}&until={until}&limit=50"
+    response = api(client, p)
+    assert len(response["results"]) == 50
+    for r in response["results"]:
+        assert r["failure"] == True, r
+
+
+def test_list_measurements_failure_false_fastpath(app, client):
+    since = datetime.utcnow().date()
+    until = since + timedelta(days=1)
+    p = f"measurements?failure=false&since={since}&until={until}&limit=50"
+    response = api(client, p)
+    assert len(response["results"]) == 50
+    for r in response["results"]:
+        assert r["failure"] == False, r
+
+
 # category_code support: briefly tested by adding this to
 # measurements/openapi/measurements.yml
 # - name: category_code

--- a/tests/integ/test_integration.py
+++ b/tests/integ/test_integration.py
@@ -435,3 +435,19 @@ def test_bug_142_twitter(app, client):
     assert len(rows) == 50
     for r in rows:
         assert "twitter" in r["input"], r
+
+
+def test_slow_inexistent_domain(app, client):
+    # time-unbounded query, filtering by a domain never monitored
+    p = "measurements?domain=meow.com&until=2019-12-11&limit=50"
+    response = api(client, p)
+    rows = tuple(response["results"])
+    assert len(rows) == 0
+
+
+def test_slow_domain(app, client):
+    # time-unbounded query, filtering by a popular domain
+    p = "measurements?domain=twitter.com&until=2019-12-11&limit=50"
+    response = api(client, p)
+    rows = tuple(response["results"])
+    assert rows


### PR DESCRIPTION
- Move away from SQLAlchemy models
- Fix logic to merge measurements between pipeline and fastpath
- Many big speed improvements
- Order by measurement_start_time by default
- Add support for domain_input
- Add commented-out, but tested support for category_code
- Increase test coverage
