### PR TITLE
Generate metrics on query runtime

### DIFF
--- a/measurements/app.py
+++ b/measurements/app.py
@@ -116,6 +116,8 @@ def extract_client_ipaddr_for_throttling():
     return ipaddr
 
 
+from prometheus_flask_exporter import PrometheusMetrics
+
 def create_app(*args, testmode=False, **kw):
     from measurements import views
 
@@ -129,6 +131,8 @@ def create_app(*args, testmode=False, **kw):
     init_app(app, testmode=testmode)
     check_config(app.config)
 
+    # Setup Database connector
+    app.prometheus_metrics = PrometheusMetrics(app)
     init_db(app)
 
     # Setup throttling

--- a/measurements/config.py
+++ b/measurements/config.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 import os
 
 from flask import request
+from prometheus_flask_exporter.multiprocess import GunicornPrometheusMetrics
 
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
@@ -44,6 +45,14 @@ REPORT_INDEX_OFFSET = int(os.environ.get("REPORT_INDEX_OFFSET", "635830"))
 
 REQID_HDR = "X-Request-ID"
 
+# We do a lazy setup, and populate the app inside of create_app
+try:
+    metrics = GunicornPrometheusMetrics(app=None, group_by="endpoint")
+except ValueError:
+    from prometheus_flask_exporter import PrometheusMetrics
+    # In testing we should use the standard PrometheusMetrics due to:
+    # env prometheus_multiproc_dir is not set or not a directory
+    metrics = PrometheusMetrics(app=None, group_by="endpoint")
 
 def request_id():
     if request:

--- a/measurements/database.py
+++ b/measurements/database.py
@@ -15,19 +15,15 @@ from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy_utils import database_exists, create_database
 
-from measurements.config import request_id
+from measurements.config import request_id, metrics
 
-from prometheus_client import Gauge
+from prometheus_client import Summary
 
-from flask import current_app
-
-query_time_gauge = None
-
+query_time = Summary("query", "query", ["hash", ], registry=metrics.registry)
 Base = declarative_base()
 
 
 def init_db(app):
-    global query_time_gauge
     if os.path.exists("/proc/sys/kernel/random/boot_id"):  # MacOS...
         with open("/proc/sys/kernel/random/boot_id") as fd:
             application_name = "measurements-{:d}-{}".format(os.getpid(), fd.read(8))
@@ -59,13 +55,6 @@ def init_db(app):
             reqid = application_name
         session.execute("set application_name = :reqid", {"reqid": reqid})
 
-    query_time_gauge = Gauge(
-        "query_time",
-        "query execution time",
-        ["hash",],
-        registry=app.prometheus_metrics.registry,
-    )
-
 
 def query_hash(q: str) -> str:
     return shake_128(q.encode()).hexdigest(4)
@@ -93,7 +82,7 @@ def init_query_logging(app):
         # Send query execution time to Prometheus with a hash of the statement
         # a label
         qh = query_hash(statement)
-        query_time_gauge.labels(qh).set(total_time)
+        query_time.labels(qh).observe(total_time)
 
         app.logger.debug("Query %s complete. Total time: %f", qh, total_time)
 

--- a/measurements/wsgi.py
+++ b/measurements/wsgi.py
@@ -4,9 +4,6 @@ from werkzeug.contrib.fixers import ProxyFix
 
 from measurements.app import create_app
 
-from prometheus_flask_exporter.multiprocess import GunicornPrometheusMetrics
-
 application = create_app()
 application.wsgi_app = ProxyFix(application.wsgi_app)
 
-metrics = GunicornPrometheusMetrics(application, group_by="endpoint")


### PR DESCRIPTION
ooni/backend#325
QueryCanceledError were handled as API errors leading to a traceback
being uploaded to Sentry. A query timeout is not an API bug or
error condition.
We now capture all query runtimes in a metric for prometheus.
The query statement is too long to be used as query name or label,
so we log a short hash instead.