### PR TITLE
Redirect to ooni.org/data when accessing legacy files

### DIFF
--- a/measurements/pages/__init__.py
+++ b/measurements/pages/__init__.py
@@ -138,17 +138,12 @@ def files_download(textname):
     if "/" not in textname:
         # This is for backward compatibility with the new pipeline.
         # See: https://github.com/TheTorProject/ooni-measurements/issues/44
-        rawsql = """SELECT report.textname AS report_textname
-            FROM report
-            WHERE report.textname LIKE '%' || :textname
-        """
-        q = current_app.db_session.execute(rawsql, dict(textname=textname))
-
-        first = q.fetchone()
-        if first is None:
-            raise NotFound("No file with that filename found")
-
-        return redirect("/files/download/%s" % first[0])
+        #
+        # It handles cases where the download path does not include the
+        # bucket_date (ex. /files/download/2020-01-01/reportfile.json vs
+        # /files/download/reportfile.json) and will redirect to
+        # https://ooni.org/data
+        return redirect('https://ooni.org/data/', code=301)
 
     rawsql = """
     SELECT *


### PR DESCRIPTION
We noticed several bots where hitting this API endpoint and the query used to implement the backward compatibility layer is very database heavy.

The original purpose of the:
```
if "/" not in textname
```

block was to handle cases such as:

`/files/download/20170219T234434Z-BE-AS47377-web_connectivity-20170219T234436Z_AS47377_BolK4y8ZwDCTaOO0hQx79Sne3lRwHJpcSmm7BdjsTnVhaO6k7z-0.2.0-probe.json`

Where the bucket_date is missing, because it's a legacy URL, and hence we needed to redirect to `/files/download/$BUCKET_DATE/20170219T234434Z-BE-AS47377-web_connectivity-20170219T234436Z_AS47377_BolK4y8ZwDCTaOO0hQx79Sne3lRwHJpcSmm7BdjsTnVhaO6k7z-0.2.0-probe.json`.

The query to do so was a very expensive LIKE `%` prefix query, which was costing us a lot of DB cycles.

From now on we are simply going to redirect to ooni.org/data in these cases taking load off from the database.