### PR TITLE
Update css file name from ooni.org

### DIFF
--- a/measurements/templates/base.html
+++ b/measurements/templates/base.html
@@ -8,7 +8,7 @@
   {% endblock %}
 
   {% block head_css %}
-    <link href="https://ooni.org/css/bootstrap.min.b805712033614b1078c3d1d1c4f8144b2345a0a5fcb7b09ee27ab92454ddfc87.css"
+    <link href="https://ooni.org/css/bootstrap.min.eea8b4fc7fc3a0fb28a6ae9bf723bde9f4ee7a602514aacd85ba56e6fbaea756.css"
           rel="stylesheet" />
     <link href="https://ooni.org/css/master.css"
           rel="stylesheet" />


### PR DESCRIPTION
Fixes ooni/backend#440

@hellais For the missing fonts problem, the best solution is to configure CORS policy on `ooni.org` 