### PR TITLE
feat: add dnscheck, urlgetter experiment names

### DIFF
--- a/newapi/debian/changelog
+++ b/newapi/debian/changelog
@@ -1,3 +1,9 @@
+ooni-api (0.13) unstable; urgency=medium
+
+  * add dnscheck, urlgetter experiment names
+
+ -- Federico Ceratto <federico@debian.org>  Wed, 02 Dec 2020 16:12:30 +0000
+
 ooni-api (0.12) unstable; urgency=medium
 
   * Add reactive test-lists

--- a/newapi/ooniapi/measurements.py
+++ b/newapi/ooniapi/measurements.py
@@ -490,6 +490,8 @@ def list_measurements():
         - psiphon
         - tor
         - riseupvpn
+        - dnscheck
+        - urlgetter
       - name: since
         in: query
         type: string
@@ -940,6 +942,8 @@ def get_aggregated():
         - psiphon
         - tor
         - riseupvpn
+        - dnscheck
+        - urlgetter
       - name: since
         in: query
         type: string

--- a/newapi/ooniapi/private.py
+++ b/newapi/ooniapi/private.py
@@ -167,6 +167,8 @@ def api_private_test_names():
         "web_connectivity": "Web Connectivity",
         "whatsapp": "WhatsApp",
         "riseupvpn": "RiseupVPN",
+        "dnscheck": "DNS Check",
+        "urlgetter": "URL Getter",
     }
     test_names = [{"id": k, "name": v} for k, v in TEST_NAMES.items()]
     return cachedjson(1, test_names=test_names)


### PR DESCRIPTION
This diff adds the dnscheck and urlgetter experiment names. Before
preparing this diff, I've added basic specs for both.

We would like to have dnscheck public, since it's our goal to land
dnscheck in production probes soon. Therefore, we would also like to
be able to see its results in the OONI Explorer.

Regarding urlgetter, we're using it as a testbed for QUIC experiments
and it's quite useful to us to be able to see it in Explorer. At the
same time, we've used urlgetter in the past for some blog posts, when
the previous API allowed us to see urlgetter results. Therefore, it
is quite beneficial to expose also this experiment.

The reference issue is: https://github.com/ooni/probe-engine/issues/1056.

(The issue mentions urlgetter only, but since I was touching API names
I thought: why not seize the day and expose also dsncheck now?)