### PR TITLE
Sync client and server API definition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,14 @@
-# Build: run ooni-sysadmin.git/scripts/docker-build from this directory
 
-FROM python:3.7-slim
+FROM debian:buster
 ENV PYTHONUNBUFFERED 1
-
 ENV PYTHONPATH /app/
-
-# Setup the locales in the Dockerfile
-RUN set -x \
-    && apt-get update \
-    && apt-get install locales -y \
-    && locale-gen en_US.UTF-8
-
-# Install measurements Dependencies
-RUN set -x \
-    && apt-get update \
-    && apt-get install git postgresql-client bzip2 gcc g++ make \
-        libpq-dev libffi-dev --no-install-recommends -y \
-    && apt-get autoremove -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-COPY requirements /tmp/requirements
-
-# Install Python dependencies
-RUN set -x \
-    && pip install -U pip setuptools \
-    && pip install -r /tmp/requirements/tests.txt \
-    && pip install -r /tmp/requirements/deploy.txt \
-                   -r /tmp/requirements/main.txt
+COPY build_docker.sh /tmp/
+RUN /tmp/build_docker.sh
 
 # Copy the directory into the container
-COPY . /app/
+COPY newapi /app/
+
+COPY newapi/debian/etc/ooni/api.conf /etc/ooni/api.conf
 
 # Set our work directory to our app directory
 WORKDIR /app/

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Clone the API repository.
 Set up a local database or a port forwarding.
 
 ```bash
-ssh amsmetadb.ooni.nu  -L 0.0.0.0:15432:127.0.0.1:5432 -Snone -g -C
+ssh amsmetadb.ooni.nu  -L 0.0.0.0:5432:127.0.0.1:5432 -Snone -g -C
 ```
 
 Create a new test in tests/integ/test_integration.py and run it with:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ curl http://127.0.0.1:5000/api/v1/measurements?since=2019-01-01&until=2019-02-01
 ```bash
 docker build -t ooniapi .
 
-docker run --name ooniapirun --rm -i -t ooniapi gunicorn3 --reuse-port ooniapi.wsgi --statsd-host 127.0.0.1:8125 --reuse-port
+docker run --name ooniapirun --rm  --net=host -i -t ooniapi gunicorn3 --reuse-port ooniapi.wsgi --statsd-host 127.0.0.1:8125
 ```
 
 ### Running the tests

--- a/README.md
+++ b/README.md
@@ -6,28 +6,32 @@ File bugs with the API inside of: https://github.com/ooni/backend/issues/new
 
 ## Local development
 
-### Requirements
-
-* Docker
-* Make
-* Python >= 3.5
-* Postgresql
-
 ### Quickstart
 
 **Note**: the default database configuration is `postgres@localhost:15432/ooni_measurements`,
 you only need to run the second step below (`export DATABASE_URL`) in case you want to use a different one.
 
-### Running the API locally
+### Running the API on Debian Buster
+
+Option 1: Build a package with dpkg-buildpackage -us -uc and install it with sudo debi
+
+Option 2: Install the dependencies from newapi/debian/control or using the commands in build_docker.sh
 
 ```bash
-tox -e run
 
 # Monitor the generated metrics
 watch -n1 -d 'curl -s http://127.0.0.1:5000/metrics'
 
 # Call the API
 curl http://127.0.0.1:5000/api/v1/measurements?since=2019-01-01&until=2019-02-01&limit=1
+```
+
+### Running the API using Docker
+
+```bash
+docker build -t ooniapi .
+
+docker run --name ooniapirun --rm -i -t ooniapi gunicorn3 --reuse-port ooniapi.wsgi --statsd-host 127.0.0.1:8125 --reuse-port
 ```
 
 ### Running the tests

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Called from Dockerfile
+set -exu
+export DEBIAN_FRONTEND=noninteractive
+
+echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list
+
+apt-get update
+apt-get install --no-install-recommends -y ca-certificates
+echo 'deb [trusted=yes] https://dl.bintray.com/ooni/internal-pull-requests unstable main' \
+  > /etc/apt/sources.list.d/ooni.list
+apt-get update
+
+apt-get install locales -y
+locale-gen en_US.UTF-8
+apt-get install git --no-install-recommends -y \
+      gunicorn3 \
+      python3-boto3 \
+      python3-flasgger \
+      python3-flask \
+      python3-flask-cors \
+      python3-flask-restful \
+      python3-flask-security \
+      python3-lz4 \
+      python3-lz4framed \
+      python3-psycopg2 \
+      python3-pytest \
+      python3-setuptools \
+      python3-sqlalchemy \
+      python3-sqlalchemy-utils \
+      python3-statsd \
+      python3-systemd \
+      python3-ujson
+apt-get autoremove -y
+apt-get clean
+rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+mkdir /etc/ooni/

--- a/newapi/debian/control
+++ b/newapi/debian/control
@@ -13,7 +13,7 @@ Build-Depends: debhelper-compat (= 12),
  python3-statsd,
  python3-systemd,
  python3-ujson
-Standards-Version: 4.5.0
+Standards-Version: 4.5.1
 
 Package: ooni-api
 Architecture: all

--- a/newapi/ooniapi/prio.py
+++ b/newapi/ooniapi/prio.py
@@ -200,10 +200,14 @@ def list_test_urls():
           type: object
           properties:
             metadata:
-              count:
-                type: integer
+              type: object
+              properties:
+                count:
+                  type: integer
             results:
+              type: array
               items:
+                type: object
                 properties:
                   category_code:
                     type: string


### PR DESCRIPTION
With the changes in this diff, we have no differences between the client and the server's view of the API.

This branch uses https://github.com/ooni/api/pull/219, which really helped me to run the API locally and fix all the issues.

See https://github.com/ooni/probe/issues/1355