### PR TITLE
Support 32 bit ASNs

### DIFF
--- a/newapi/ooniapi/probe_services.py
+++ b/newapi/ooniapi/probe_services.py
@@ -679,7 +679,7 @@ def open_report():
 
     log.info("Open report %r", data)
     asn = data.get("probe_asn", "AS0").upper()
-    if len(asn) > 8 or len(asn) < 3 or not asn.startswith("AS"):
+    if len(asn) > 12 or len(asn) < 3 or not asn.startswith("AS"):
         asn = "AS0"
     try:
         asn_i = int(asn[2:])


### PR DESCRIPTION
While the currently longest allocated ASN is 401309 (see: https://www.iana.org/assignments/as-numbers/as-numbers.xhtml), it's theoretically possible for them to be longer than 8 characters. We should make this future proof so we don't forget about it when they do start allocating them.