### PR TITLE
0.49 Fix logic of citizenlab URL submission backend

### DIFF
--- a/newapi/debian/changelog
+++ b/newapi/debian/changelog
@@ -1,3 +1,9 @@
+ooni-api (0.47) unstable; urgency=medium
+
+  * Bump up gunicorn workers
+
+ -- Federico Ceratto <federico@debian.org>  Tue, 09 Nov 2021 11:37:30 +0000
+
 ooni-api (0.46) unstable; urgency=medium
 
   * Add debugging around PR opening

--- a/newapi/debian/changelog
+++ b/newapi/debian/changelog
@@ -1,3 +1,9 @@
+ooni-api (0.46) unstable; urgency=medium
+
+  * Add debugging around PR opening
+
+ -- Federico Ceratto <federico@debian.org>  Mon, 11 Oct 2021 14:20:17 +0100
+
 ooni-api (0.45) unstable; urgency=medium
 
   * Fix category filtering

--- a/newapi/debian/ooni-api.service
+++ b/newapi/debian/ooni-api.service
@@ -4,7 +4,8 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-ExecStart=/usr/bin/gunicorn3 --workers 3 \
+ExecStart=/usr/bin/gunicorn3 \
+  --workers 12 \
   --statsd-host 127.0.0.1:8125 --statsd-prefix ooni-api \
   --reuse-port \
   ooniapi.wsgi

--- a/newapi/ooniapi/app.py
+++ b/newapi/ooniapi/app.py
@@ -62,6 +62,7 @@ def validate_conf(app, conffile):
         "GITHUB_ORIGIN_REPO",
         "GITHUB_PUSH_REPO",
         "GITHUB_TOKEN",
+        "GITHUB_USER",
         "GITHUB_WORKDIR",
         "JWT_ENCRYPTION_KEY",
         "LOGIN_BASE_URL",

--- a/newapi/ooniapi/citizenlab.py
+++ b/newapi/ooniapi/citizenlab.py
@@ -190,7 +190,7 @@ class URLListManager:
         """
         apiurl = self.get_pr_id(account_id)
         pr_num = apiurl.split("/")[-1]
-        return f"https://github.com/{self.push_repo}/pull/{pr_num}"
+        return f"https://github.com/{self.origin_repo}/pull/{pr_num}"
 
     def get_user_repo(self, account_id: str):
         repo_path = self.get_user_repo_path(account_id)

--- a/newapi/ooniapi/citizenlab.py
+++ b/newapi/ooniapi/citizenlab.py
@@ -368,7 +368,7 @@ class URLListManager:
         https://api.github.com/repos/citizenlab/test-lists/pulls/800
         """
         head = f"{self.push_username}:{branchname}"
-        log.info(f"opening a PR for {head} on {self.origin_repo}")
+        log.info(f"opening a PR for {head} on {self.origin_repo} using {self.push_repo}")
         auth = HTTPBasicAuth(self.github_user, self.github_token)
         apiurl = f"https://api.github.com/repos/{self.origin_repo}/pulls"
         r = requests.post(

--- a/newapi/ooniapi/citizenlab.py
+++ b/newapi/ooniapi/citizenlab.py
@@ -98,13 +98,14 @@ class ProgressPrinter(git.RemoteProgress):
 
 
 class URLListManager:
-    def __init__(self, working_dir, github_token, push_repo, origin_repo):
+    def __init__(self, working_dir, github_user, github_token, push_repo, origin_repo):
         self.working_dir = working_dir
         self.origin_repo = origin_repo
         self.push_repo = push_repo
-        self.github_user = push_repo.split("/")[0]
+        self.github_user = github_user
         self.github_token = github_token
         self.repo_dir = self.working_dir / "test-lists"
+        self.push_username = push_repo.split("/")[0]
 
         self.repo = self.init_repo()
 
@@ -366,17 +367,17 @@ class URLListManager:
         """Opens PR. Returns API URL e.g.
         https://api.github.com/repos/citizenlab/test-lists/pulls/800
         """
-        head = f"{self.github_user}:{branchname}"
-        log.info(f"opening a PR for {head} on {self.push_repo}")
+        head = f"{self.push_username}:{branchname}"
+        log.info(f"opening a PR for {head} on {self.origin_repo}")
         auth = HTTPBasicAuth(self.github_user, self.github_token)
-        apiurl = f"https://api.github.com/repos/{self.push_repo}/pulls"
+        apiurl = f"https://api.github.com/repos/{self.origin_repo}/pulls"
         r = requests.post(
             apiurl,
             auth=auth,
             json={
                 "head": head,
                 "base": "master",
-                "title": "Pull requests from the web",
+                "title": "Contribution from test-lists.ooni.org",
             },
         )
         j = r.json()
@@ -482,6 +483,7 @@ def get_url_list_manager():
     conf = current_app.config
     return URLListManager(
         working_dir=Path(conf["GITHUB_WORKDIR"]),
+        github_user=conf["GITHUB_USER"],
         github_token=conf["GITHUB_TOKEN"],
         origin_repo=conf["GITHUB_ORIGIN_REPO"],
         push_repo=conf["GITHUB_PUSH_REPO"],

--- a/newapi/ooniapi/citizenlab.py
+++ b/newapi/ooniapi/citizenlab.py
@@ -380,7 +380,12 @@ class URLListManager:
             },
         )
         j = r.json()
-        return j["url"]
+        try:
+            url = j["url"]
+            return url
+        except KeyError:
+            log.error(f"Failed to retrieve URL for the PR {j}")
+            raise
 
     def is_pr_resolved(self, account_id) -> bool:
         """Raises if the PR was never opened"""
@@ -404,10 +409,10 @@ class URLListManager:
     def propose_changes(self, account_id: str) -> str:
         with self.get_user_lock(account_id):
             log.debug("proposing changes")
-            self.set_state(account_id, "PR_OPEN")
             self.push_to_repo(account_id)
             pr_id = self.open_pr(self.get_user_branchname(account_id))
             self.set_pr_id(account_id, pr_id)
+            self.set_state(account_id, "PR_OPEN")
             return pr_id
 
 


### PR DESCRIPTION
Previously it would not work properly when configured in our testing vs
production setup as several assumptions were made about the push and
origin repos.

Specifically:

1. The github_username was being derived from the push_repo address,
which might not be a username in the case of a repo configured under a
github org

2. The address used for opening pull requests was the push_repo, it
should instead be the origin_repo