### PR TITLE
Clickhouse localdev

### DIFF
--- a/.github/workflows/test_new_api.yml
+++ b/.github/workflows/test_new_api.yml
@@ -21,24 +21,15 @@ jobs:
         with:
           limit-access-to-actor: true
 
-      - name: Run integ tests
-        # Uses Dockerfile ./build_runner.sh and docker-compose.yml to set up the runner
-        run: |
-          docker-compose run --rm api \
-            pytest-3 -vv --cov=ooniapi \
-              --create-db \
-              tests/functional/test_private_explorer.py \
-              tests/integ/test_aggregation.py \
-              tests/integ/test_citizenlab.py \
-              tests/integ/test_integration.py \
-              tests/integ/test_integration_auth.py \
-              tests/integ/test_prioritization.py \
-              tests/integ/test_private_api.py \
-              tests/integ/test_probe_services.py \
-              tests/unit/test_prio.py
-              #tests/integ/test_prioritization_nodb.py \
-              #tests/integ/test_probe_services_nodb.py \
-              #tests/integ/test_integration_auth.py \
+
+      - name: Build docker image
+        run: make build
+
+      - name: Setup database fixtures
+        run: make initdb
+
+      - name: Run all tests
+        run: T="--show-capture=no -s -vv --cov=ooniapi" make tests
 
       - name: debug docker
         if: always()

--- a/README.md
+++ b/README.md
@@ -6,81 +6,41 @@ File bugs with the API inside of: https://github.com/ooni/backend/issues/new
 
 ## Local development
 
+You can run the OONI API locally in a development environment using `docker`
+and `docker-compose`. Follow the instructions below to set it up.
+
 ### Quickstart
 
-**Note**: the default database configuration is `postgres@localhost:15432/ooni_measurements`,
-you only need to run the second step below (`export DATABASE_URL`) in case you want to use a different one.
-
-### Running the API on Debian Buster
-
-Option 1: Build a package with dpkg-buildpackage -us -uc and install it with sudo debi
-
-Option 2: Install the dependencies from newapi/debian/control or using the commands in build_docker.sh
-
-```bash
-
-# Monitor the generated metrics
-watch -n1 -d 'curl -s http://127.0.0.1:5000/metrics'
-
-# Call the API
-curl http://127.0.0.1:5000/api/v1/measurements?since=2019-01-01&until=2019-02-01&limit=1
+First you should build the docker image for the API:
+```
+make build
 ```
 
-### Running the API using Docker
+This only needs to be run once, or any time you make changes to the
+dependencies in the `newapi/build_runnner.sh` script.
 
-```bash
-docker build -t ooniapi .
-
-docker run --name ooniapirun --rm  --net=host -i -t ooniapi gunicorn3 --reuse-port ooniapi.wsgi --statsd-host 127.0.0.1:8125
+To populate the database with some sample data (this is needed for running many
+of the tests), you should run:
+```
+make initdb
 ```
 
-### Running The API using systemd-nspawn
+This also needs to only be run once.
 
-```bash
-cd newapi
-./spawnrunner gunicorn3 --reuse-port ooniapi.wsgi --statsd-host 127.0.0.1:8125
+At this point you have a fully setup development environment.
+
+You can run the full test suite via:
+```
+make tests
 ```
 
-### Running tests using systemd-nspawn
-
-```bash
-cd newapi
-./spawnrunner pytest-3 tests/integ/test_probe_services.py
+If you care to only run a specific test, that can be done using the `pytest`
+`-k` option, passed in as a T env var to `make`:
+```
+T="-k test_my_test_name" make tests
 ```
 
-### Running the API using gunicorn on macOS
-
-First setup a local port forward with:
-
-```bash
-ssh ams-pg-test.ooni.org -L 0.0.0.0:5432:127.0.0.1:5432 -Snone -g -C
+If you want to run a local instance of the OONI API, this can be done via:
 ```
-
-Run the newapi under gunicorn:
-
+make serve
 ```
-cd newapi
-CONF=$(pwd)/api.conf.example gunicorn --reuse-port ooniapi.wsgi
-```
-
-### Running the tests
-
-Run the integration tests:
-
-```bash
-docker-compose run --rm api pytest-3 -k test_private_explorer.py -k test_smoke.py -k test_citizenlab.py
-```
-
-### Bug fix micro-tutorial
-
-Clone the API repository.
-
-Create a new test in `tests/integ/test_integration.py` and run it with:
-
-```bash
-docker-compose run --rm api pytest-3 -k test_bug_12345_blah
-```
-
-Fix the bug and send a pull request for the bugfix and test together.
-
-Thanks!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,15 +10,18 @@ services:
       - "9000:9000"
     volumes:
       - ./data/clickhouse/data:/var/lib/clickhouse
+    healthcheck:
+      test: ["CMD", "wget", "-q", "http://127.0.0.1:8123/ping"]
 
   api:
     restart: always
     build:
       context: .
-    command: gunicorn3 --reuse-port ooniapi.wsgi --statsd-host 127.0.0.1:8125
+    command: gunicorn3 --reuse-port ooniapi.wsgi -b 0.0.0.0:8000
     volumes:
       - ./newapi/:/app
     ports:
       - "8000:8000"
     depends_on:
-      - clickhouse
+      clickhouse:
+        condition: service_healthy

--- a/newapi/build_runner.sh
+++ b/newapi/build_runner.sh
@@ -41,7 +41,9 @@ apt-get install --no-install-recommends -qy \
   python3-mock \
   python3-psycopg2 \
   python3-pytest \
+  python3-pytest-benchmark\
   python3-pytest-cov \
+  python3-pytest-mock \
   python3-setuptools \
   python3-sqlalchemy \
   python3-sqlalchemy-utils \

--- a/newapi/debian/control
+++ b/newapi/debian/control
@@ -44,8 +44,6 @@ Depends: ${misc:Depends},
  python3-ujson,
 Suggests:
  python3-freezegun,
- python3-pytest,
- python3-pytest-mock,
- python3-pytest-benchmark
+ python3-pytest
 Description: OONI API
  OONI API

--- a/newapi/tests/integ/test_prioritization_nodb.py
+++ b/newapi/tests/integ/test_prioritization_nodb.py
@@ -49,7 +49,8 @@ def mockdb(query, *query_kw):
 
 @pytest.fixture
 def nodb(app):
-    app.db_session.execute = mockdb
+    if hasattr(app, "db_session"):
+        app.db_session.execute = mockdb
 
 
 def getjson(client, url):

--- a/newapi/tests/integ/test_probe_services_nodb.py
+++ b/newapi/tests/integ/test_probe_services_nodb.py
@@ -56,7 +56,8 @@ def mockdb(query, *query_kw):
 
 @pytest.fixture
 def nodb(app):
-    app.db_session.execute = mockdb
+    if hasattr(app, "db_session"):
+        app.db_session.execute = mockdb
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR updates the documentation and tooling around setting up a cross platform dev environment for the OONI API.

In trying to setup my development environment for running locally all the OONI API tests, I realised that the documentation was out of date and that we had so many different ways of doing things (how we recommend in the README vs how tests are run by the CI vs what is in the Makefile) that leads to confusion. I therefore decided to take a stab at improving the situation a bit.

Specifically what I did is as follows:
- Restored a `Makefile` based approach for setting up the dev environment with 3 simple commands: `build`, `initdb` and `tests`
- Improve the `docker-compose.yml` definition to avoid duplicating the work already being done inside of pytest for the database fixture setup
- Updated the `build_runner.sh` script to include recently added dependencies that were missing
- Updated the CI scripts so that they use the same commands as those documented in the Readme
- Removed some dead/duplicate code in the top level directory
- Removed from the Readme the many different ways of setting up the dev environment (I think we should document and support one cross platform method, ie. docker+docker-compose, so as to improve developer experience)

The changes I made should not impact anything non-docker related, so the previous workflows should still be possible.