### PR TITLE
Implement support for returning metadata about a domain

### DIFF
--- a/newapi/ooniapi/private.py
+++ b/newapi/ooniapi/private.py
@@ -844,6 +844,29 @@ def api_private_circumvention_runtime_stats() -> Response:
 
 @api_private_blueprint.route("/domain_metadata")
 def api_private_domain_metadata() -> Response:
+    """
+    The goal of this endpoint is to return the primary category code of a
+    certain domain_name and it's canonical representation.
+    We consider the primary category code to be the category code of whatever is
+    the shortest URL in the test lists giving higher priority to what is in the
+    global list (ex. if we have https://twitter.com/amnesty categorised as HUMR
+    and https://twitter.com/ as GRP, we will be picking GRP as the canonical
+    category code).
+    The canonical representation of a domain is whatever is present in the
+    global list or if it's not present, then the shortest possible
+    representation. 
+    Some research related to this problem was done here:
+    https://gist.github.com/hellais/fab319ae20b0ccca7b548a060ed66e14, where some
+    notes were taken on what fixes need to be done in the test-lists to ensure
+    all of this works as expected (ex. moving shortest URL representations from
+    the country lists into the global list).
+
+    Returns:
+    {
+        "category_code": "CITIZENLAB_CATEGORY_CODE",
+        "canonical_domain": "canonical.tld"
+    }
+    """
     domain = request.args.get("domain")
     if domain is None:
         raise BadRequest("missing domain")

--- a/newapi/ooniapi/private.py
+++ b/newapi/ooniapi/private.py
@@ -854,7 +854,7 @@ def api_private_domain_metadata() -> Response:
     category code).
     The canonical representation of a domain is whatever is present in the
     global list or if it's not present, then the shortest possible
-    representation. 
+    representation in the other test lists.
     Some research related to this problem was done here:
     https://gist.github.com/hellais/fab319ae20b0ccca7b548a060ed66e14, where some
     notes were taken on what fixes need to be done in the test-lists to ensure
@@ -899,7 +899,7 @@ def api_private_domain_metadata() -> Response:
         # shortest domain among the one with and without www
         res2 = query_click_one_row(
             f"""
-            SELECT category_code FROM citizenlab 
+            SELECT category_code, domain FROM citizenlab 
             WHERE ({domain_q})
             ORDER BY length(url)
             LIMIT 1
@@ -908,6 +908,7 @@ def api_private_domain_metadata() -> Response:
         )
         if res2:
             category_code = res2["category_code"]
+            canonical_domain = res2["domain"]
     else:
         category_code = res["category_code"]
         canonical_domain = res["domain"]

--- a/newapi/ooniapi/private.py
+++ b/newapi/ooniapi/private.py
@@ -859,6 +859,7 @@ def api_private_domain_metadata() -> Response:
 
     params = {str(idx): d for idx, d in enumerate(domain_variations)}
     domain_q = "OR ".join([f"domain = %({idx})s " for idx in params.keys()])
+    # case 1: domain with or without www is in the global list (cc = 'ZZ')
     res = query_click_one_row(
         f"""
         SELECT category_code, domain 

--- a/newapi/ooniapi/private.py
+++ b/newapi/ooniapi/private.py
@@ -845,6 +845,8 @@ def api_private_circumvention_runtime_stats() -> Response:
 @api_private_blueprint.route("/domain_metadata")
 def api_private_domain_metadata() -> Response:
     domain = request.args.get("domain")
+    if domain is None:
+        raise BadRequest("missing domain")
 
     domain_variations = [domain]
     if domain.startswith("www."):

--- a/newapi/ooniapi/private.py
+++ b/newapi/ooniapi/private.py
@@ -916,5 +916,4 @@ def api_private_domain_metadata() -> Response:
         "2h",
         category_code=category_code,
         canonical_domain=canonical_domain,
-        domain=domain,
     )

--- a/newapi/ooniapi/private.py
+++ b/newapi/ooniapi/private.py
@@ -871,6 +871,8 @@ def api_private_domain_metadata() -> Response:
         params,
     )
     if not res:
+        # case 2: domain only inside a country list, so we just select the
+        # shortest domain among the one with and without www
         res2 = query_click_one_row(
             f"""
             SELECT category_code FROM citizenlab 

--- a/newapi/ooniapi/private.py
+++ b/newapi/ooniapi/private.py
@@ -844,16 +844,15 @@ def api_private_circumvention_runtime_stats() -> Response:
 
 @api_private_blueprint.route("/domain_metadata")
 def api_private_domain_metadata() -> Response:
-    """
-    The goal of this endpoint is to return the primary category code of a
-    certain domain_name and it's canonical representation.
+    """ Return the primary category code of a certain domain_name and its
+    canonical representation.
     We consider the primary category code to be the category code of whatever is
     the shortest URL in the test lists giving higher priority to what is in the
-    global list (ex. if we have https://twitter.com/amnesty categorised as HUMR
+    global list (e.g. if we have https://twitter.com/amnesty categorised as HUMR
     and https://twitter.com/ as GRP, we will be picking GRP as the canonical
     category code).
     The canonical representation of a domain is whatever is present in the
-    global list or if it's not present, then the shortest possible
+    global list. If it's not present, then the shortest possible
     representation in the other test lists.
     Some research related to this problem was done here:
     https://gist.github.com/hellais/fab319ae20b0ccca7b548a060ed66e14, where some
@@ -885,10 +884,10 @@ def api_private_domain_metadata() -> Response:
     # case 1: domain with or without www is in the global list (cc = 'ZZ')
     res = query_click_one_row(
         f"""
-        SELECT category_code, domain 
-        FROM citizenlab 
+        SELECT category_code, domain
+        FROM citizenlab
         WHERE ({domain_q})
-        AND cc = 'ZZ' 
+        AND cc = 'ZZ'
         ORDER BY length(url)
         LIMIT 1
     """,
@@ -899,7 +898,7 @@ def api_private_domain_metadata() -> Response:
         # shortest domain among the one with and without www
         res2 = query_click_one_row(
             f"""
-            SELECT category_code, domain FROM citizenlab 
+            SELECT category_code, domain FROM citizenlab
             WHERE ({domain_q})
             ORDER BY length(url)
             LIMIT 1

--- a/newapi/tests/integ/clickhouse_2_fixtures.sql
+++ b/newapi/tests/integ/clickhouse_2_fixtures.sql
@@ -7,7 +7,7 @@ INSERT INTO test_groups (test_name, test_group) VALUES ('bridge_reachability', '
 INSERT INTO citizenlab VALUES ('www.ushmm.org', 'https://www.ushmm.org/', 'ZZ', 'CULTR');
 INSERT INTO citizenlab VALUES ('www.cabofrio.rj.gov.br', 'http://www.cabofrio.rj.gov.br/', 'BR', 'CULTR');
 INSERT INTO citizenlab VALUES ('ncac.org', 'http://ncac.org/', 'ZZ', 'NEWS');
-INSERT INTO citizenlab VALUES ('www.facebook.com', 'https://ncac.org/', 'ZZ', 'NEWS');
+INSERT INTO citizenlab VALUES ('ncac.org', 'https://ncac.org/', 'ZZ', 'NEWS');
 INSERT INTO citizenlab VALUES ('www.facebook.com','http://www.facebook.com/saakashvilimikheil','ge','NEWS');
 INSERT INTO citizenlab VALUES ('www.facebook.com','http://www.facebook.com/somsakjeam/videos/1283095981743678/','th','POLR');
 INSERT INTO citizenlab VALUES ('www.facebook.com','https://www.facebook.com/','ZZ','GRP');

--- a/newapi/tests/integ/clickhouse_2_fixtures.sql
+++ b/newapi/tests/integ/clickhouse_2_fixtures.sql
@@ -7,6 +7,15 @@ INSERT INTO test_groups (test_name, test_group) VALUES ('bridge_reachability', '
 INSERT INTO citizenlab VALUES ('www.ushmm.org', 'https://www.ushmm.org/', 'ZZ', 'CULTR');
 INSERT INTO citizenlab VALUES ('www.cabofrio.rj.gov.br', 'http://www.cabofrio.rj.gov.br/', 'BR', 'CULTR');
 INSERT INTO citizenlab VALUES ('ncac.org', 'http://ncac.org/', 'ZZ', 'NEWS');
+INSERT INTO citizenlab VALUES ('www.facebook.com', 'https://ncac.org/', 'ZZ', 'NEWS');
+INSERT INTO citizenlab VALUES ('www.facebook.com','http://www.facebook.com/saakashvilimikheil','ge','NEWS');
+INSERT INTO citizenlab VALUES ('www.facebook.com','http://www.facebook.com/somsakjeam/videos/1283095981743678/','th','POLR');
+INSERT INTO citizenlab VALUES ('www.facebook.com','https://www.facebook.com/','ZZ','GRP');
+INSERT INTO citizenlab VALUES ('facebook.com','http://facebook.com/','ua','GRP');
+INSERT INTO citizenlab VALUES ('facebook.com','https://facebook.com/watch','jo','GRP');
+INSERT INTO citizenlab VALUES ('twitter.com','http://twitter.com/ghonim','kw','POLR');
+INSERT INTO citizenlab VALUES ('twitter.com','http://twitter.com/ghonim','so','POLR');
+INSERT INTO citizenlab VALUES ('twitter.com','https://twitter.com/','ZZ','GRP');
 
 -- get_measurement_meta integ tests
 INSERT INTO jsonl (report_id, input, s3path, linenum) VALUES ('20210709T004340Z_webconnectivity_MY_4818_n1_YCM7J9mGcEHds2K3', 'https://www.backtrack-linux.org/', 'raw/20210709/00/MY/webconnectivity/2021070900_MY_webconnectivity.n0.2.jsonl.gz', 35)

--- a/newapi/tests/integ/test_private_api.py
+++ b/newapi/tests/integ/test_private_api.py
@@ -23,7 +23,7 @@ def test_private_api_asn_by_month(client):
     r = response[0]
     assert sorted(r.keys()) == ["date", "value"]
     assert r["value"] > 10
-    assert r["value"] < 10 ** 6
+    assert r["value"] < 10**6
     assert r["date"].endswith("T00:00:00+00:00")
 
 
@@ -61,7 +61,7 @@ def test_private_api_test_names(client, log):
             {"id": "psiphon", "name": "Psiphon"},
             {"id": "riseupvpn", "name": "RiseupVPN"},
             {"id": "signal", "name": "Signal"},
-            {'id': 'stunreachability', 'name': 'STUN Reachability'},
+            {"id": "stunreachability", "name": "STUN Reachability"},
             {"id": "tcp_connect", "name": "TCP Connect"},
             {"id": "telegram", "name": "Telegram"},
             {"id": "tor", "name": "Tor"},
@@ -105,27 +105,33 @@ def test_private_api_test_coverage_with_groups(client, log):
     assert 27 < len(resp["network_coverage"]) < 32
 
 
-def test_private_api_domain_metadata(client):
+def test_private_api_domain_metadata1(client):
     url = "domain_metadata?domain=facebook.com"
     resp = privapi(client, url)
     assert resp["category_code"] == "GRP"
     assert resp["canonical_domain"] == "www.facebook.com"
 
+
+def test_private_api_domain_metadata2(client):
     url = "domain_metadata?domain=www.facebook.com"
     resp = privapi(client, url)
     assert resp["category_code"] == "GRP"
     assert resp["canonical_domain"] == "www.facebook.com"
 
+
+def test_private_api_domain_metadata3(client):
     url = "domain_metadata?domain=www.twitter.com"
     resp = privapi(client, url)
     assert resp["category_code"] == "GRP"
     assert resp["canonical_domain"] == "twitter.com"
 
+
+def test_private_api_domain_metadata4(client):
     url = "domain_metadata?domain=www.this-domain-is-not-in-the-test-lists-for-sure.com"
     resp = privapi(client, url)
     assert resp["category_code"] == "MISC"
-    assert resp["canonical_domain"] == "this-domain-is-not-in-the-test-lists-for-sure.com"
-
+    exp = "this-domain-is-not-in-the-test-lists-for-sure.com"
+    assert resp["canonical_domain"] == exp
 
 
 @pytest.mark.skip("FIXME not deterministic")

--- a/newapi/tests/integ/test_private_api.py
+++ b/newapi/tests/integ/test_private_api.py
@@ -105,6 +105,29 @@ def test_private_api_test_coverage_with_groups(client, log):
     assert 27 < len(resp["network_coverage"]) < 32
 
 
+def test_private_api_domain_metadata(client):
+    url = "domain_metadata?domain=facebook.com"
+    resp = privapi(client, url)
+    assert resp["category_code"] == "GRP"
+    assert resp["canonical_domain"] == "www.facebook.com"
+
+    url = "domain_metadata?domain=www.facebook.com"
+    resp = privapi(client, url)
+    assert resp["category_code"] == "GRP"
+    assert resp["canonical_domain"] == "www.facebook.com"
+
+    url = "domain_metadata?domain=www.twitter.com"
+    resp = privapi(client, url)
+    assert resp["category_code"] == "GRP"
+    assert resp["canonical_domain"] == "twitter.com"
+
+    url = "domain_metadata?domain=www.this-domain-is-not-in-the-test-lists-for-sure.com"
+    resp = privapi(client, url)
+    assert resp["category_code"] == "MISC"
+    assert resp["canonical_domain"] == "this-domain-is-not-in-the-test-lists-for-sure.com"
+
+
+
 @pytest.mark.skip("FIXME not deterministic")
 def test_private_api_website_networks(client, log):
     url = "website_networks?probe_cc=US"


### PR DESCRIPTION
The category code is the one of the shortest URL in the test list (with
priority to the URL in the global list)

The canonical URL is that of whatever is inside of the global or if not
present there, then it's the one of the shortest variation of the domain