### PR TITLE
Add more strict filtering on inputs on API calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TESTARGS ?= tests/functional/test_private_explorer.py tests/integ/test_aggregation.py tests/integ/test_citizenlab.py tests/integ/test_integration.py tests/integ/test_integration_auth.py tests/integ/test_prioritization.py tests/integ/test_private_api.py tests/integ/test_probe_services.py tests/unit/test_prio.py
+TESTARGS ?= tests/functional/test_private_explorer.py tests/integ/test_aggregation.py tests/integ/test_citizenlab.py tests/integ/test_integration.py tests/integ/test_integration_auth.py tests/integ/test_prioritization.py tests/integ/test_private_api.py tests/integ/test_probe_services.py tests/unit/test_prio.py tests/integ/test_params_validation.py
 
 #tests/integ/test_prioritization_nodb.py
 #tests/integ/test_probe_services_nodb.py

--- a/newapi/debian/changelog
+++ b/newapi/debian/changelog
@@ -1,3 +1,9 @@
+ooni-api (1.0.19) unstable; urgency=medium
+
+  * Filter incoming queries better
+
+ -- Federico Ceratto <federico@debian.org>  Wed, 17 Aug 2022 14:17:25 +0100
+
 ooni-api (1.0.17) unstable; urgency=medium
 
   * Support redirect_to in registration

--- a/newapi/ooniapi/auth.py
+++ b/newapi/ooniapi/auth.py
@@ -20,7 +20,7 @@ import jwt.exceptions  # debdeps: python3-jwt
 
 from ooniapi.config import metrics
 from ooniapi.database import query_click_one_row, insert_click
-from ooniapi.utils import nocachejson
+from ooniapi.utils import nocachejson, jerror
 
 origins = [
     re.compile(r"^https://[-A-Za-z0-9]+\.ooni\.org$"),
@@ -61,12 +61,6 @@ Configuration parameters:
 
 # Courtesy of https://emailregex.com/
 EMAIL_RE = re.compile(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)")
-
-
-def jerror(msg, code=400):
-    resp = make_response(jsonify(error=msg), code)
-    resp.cache_control.no_cache = True
-    return resp
 
 
 def create_jwt(payload: dict) -> str:

--- a/newapi/ooniapi/measurements.py
+++ b/newapi/ooniapi/measurements.py
@@ -328,7 +328,7 @@ def get_raw_measurement() -> Response:
     """
     # This is used by Explorer to let users download msmts
     param = request.args.get
-    report_id = param("report_id")
+    report_id = param_report_id()
     if not report_id or len(report_id) < 15:
         raise BadRequest("Invalid report_id")
     input_ = param("input")
@@ -461,7 +461,7 @@ def get_measurement_meta() -> Response:
     # TODO: input can be '' or NULL in the fastpath table - fix it
     # TODO: see integ tests for TODO items
     param = request.args.get
-    report_id = param("report_id")
+    report_id = param_report_id()
     if not report_id or len(report_id) < 15:
         raise BadRequest("Invalid report_id")
     input_ = param_url("input")
@@ -654,7 +654,7 @@ def list_measurements() -> Response:
     # made faster by OOID: https://github.com/ooni/pipeline/issues/48
     log = current_app.logger
     param = request.args.get
-    report_id = param("report_id")
+    report_id = param_report_id()
     probe_asn = param_asn("probe_asn")  # int / None
     probe_cc = param("probe_cc")
     test_name = param("test_name")
@@ -1051,6 +1051,15 @@ def param_url(name):
         return p
     url = urlparse(p)
     validate_domain(url.netloc, name)
+    return p
+
+
+def param_report_id():
+    p = request.args.get("report_id")
+    if not p or len(p) < 5 or len(p) > 100:
+        raise ValueError(f"Invalid report_id field")
+    accepted = string.ascii_letters + string.digits + "_"
+    validate(p, accepted)
     return p
 
 

--- a/newapi/ooniapi/measurements.py
+++ b/newapi/ooniapi/measurements.py
@@ -41,7 +41,7 @@ from urllib.request import urlopen
 from urllib.parse import urljoin, urlencode
 
 from ooniapi.config import metrics
-from ooniapi.utils import cachedjson
+from ooniapi.utils import cachedjson, jerror
 from ooniapi.models import TEST_NAMES
 from ooniapi.database import query_click, query_click_one_row
 

--- a/newapi/ooniapi/measurements.py
+++ b/newapi/ooniapi/measurements.py
@@ -113,7 +113,7 @@ def get_measurement(measurement_id) -> Response:
     query_params = dict(uid=measurement_id)
     lookup = query_click_one_row(sql.text(query), query_params)
     if lookup is None:
-        return make_response("Incorrect or inexistent measurement_id", 400)
+        return jerror("Incorrect or inexistent measurement_id")
 
     s3path = lookup["s3path"]
     linenum = lookup["linenum"]
@@ -122,7 +122,7 @@ def get_measurement(measurement_id) -> Response:
         body = _fetch_jsonl_measurement_body_from_s3(s3path, linenum)
     except:  # pragma: no cover
         log.error(f"Failed to fetch file {s3path} from S3")
-        return make_response("Incorrect or inexistent measurement_id", 400)
+        return jerror("Incorrect or inexistent measurement_id")
 
     resp = make_response(body)
     resp.mimetype = "application/json"

--- a/newapi/ooniapi/measurements.py
+++ b/newapi/ooniapi/measurements.py
@@ -460,10 +460,7 @@ def get_measurement_meta() -> Response:
     # TODO: see integ tests for TODO items
     param = request.args.get
     report_id = param_report_id()
-    # FIXME: support non-URL inputs for STUN and others
-    input_ = param_url("input")
-    if input_ == "":
-        input_ = None
+    input_ = param_input_or_none()
 
     full = param("full", "").lower() in ("true", "1", "yes")
     log.info(f"get_measurement_meta '{report_id}' '{input_}'")
@@ -1068,6 +1065,19 @@ def param_report_id() -> str:
     if rid is None:
         raise BadRequest(f"Invalid report_id")
     return rid
+
+
+def param_input_or_none() -> Optional[str]:
+    """Accepts any input format supported or None"""
+    p = request.args.get("input")
+    if not p:
+        return None
+    x = p.encode("ascii", "ignore").decode()
+    accepted = string.ascii_letters + string.digits + r' :/.[]-_%+(){}='
+    for c in x:
+        if c not in accepted:
+            raise ValueError(f"Invalid characters in input field")
+    return p
 
 
 @api_msm_blueprint.route("/v1/aggregation")

--- a/newapi/ooniapi/measurements.py
+++ b/newapi/ooniapi/measurements.py
@@ -464,7 +464,7 @@ def get_measurement_meta() -> Response:
     report_id = param("report_id")
     if not report_id or len(report_id) < 15:
         raise BadRequest("Invalid report_id")
-    input_ = param("input", None)
+    input_ = param_url("input")
     if input_ == "":
         input_ = None
 
@@ -489,8 +489,7 @@ def get_measurement_meta() -> Response:
         log.error(e, exc_info=True)
         body = ""
 
-    # FIXME cache timing
-    return cachedjson("0s", raw_measurement=body, **msmt_meta)
+    return cachedjson("60s", raw_measurement=body, **msmt_meta)
 
 
 # # Listing measurements

--- a/newapi/ooniapi/measurements.py
+++ b/newapi/ooniapi/measurements.py
@@ -1073,7 +1073,7 @@ def param_input_or_none() -> Optional[str]:
     if not p:
         return None
     x = p.encode("ascii", "ignore").decode()
-    accepted = string.ascii_letters + string.digits + r' :/.[]-_%+(){}='
+    accepted = string.ascii_letters + string.digits + r' :/.[]-_%+(){}=?#&!,'
     for c in x:
         if c not in accepted:
             raise ValueError(f"Invalid characters in input field")

--- a/newapi/ooniapi/measurements.py
+++ b/newapi/ooniapi/measurements.py
@@ -475,11 +475,10 @@ def get_measurement_meta() -> Response:
 
     assert isinstance(msmt_meta, dict)
     if not full:
-        # FIXME cache timing
-        return cachedjson("0s", **msmt_meta)
+        return cachedjson("60s", **msmt_meta)
 
     if msmt_meta == {}:  # measurement not found
-        return cachedjson("0s", raw_measurement="", **msmt_meta)
+        return cachedjson("60s", raw_measurement="", **msmt_meta)
 
     try:
         body = _fetch_measurement_body(report_id, input_, msmt_meta["measurement_uid"])
@@ -945,7 +944,7 @@ def _list_measurements_click(
     }
 
     response = jsonify({"metadata": metadata, "results": results[:limit]})
-    response.cache_control.max_age = 1
+    response.cache_control.max_age = 60
     return response
 
 

--- a/newapi/ooniapi/measurements.py
+++ b/newapi/ooniapi/measurements.py
@@ -464,6 +464,7 @@ def get_measurement_meta() -> Response:
     report_id = param_report_id()
     if not report_id or len(report_id) < 15:
         raise BadRequest("Invalid report_id")
+    # FIXME: support non-URL inputs for STUN and others
     input_ = param_url("input")
     if input_ == "":
         input_ = None
@@ -475,10 +476,10 @@ def get_measurement_meta() -> Response:
 
     assert isinstance(msmt_meta, dict)
     if not full:
-        return cachedjson("60s", **msmt_meta)
+        return cachedjson("1m", **msmt_meta)
 
     if msmt_meta == {}:  # measurement not found
-        return cachedjson("60s", raw_measurement="", **msmt_meta)
+        return cachedjson("1m", raw_measurement="", **msmt_meta)
 
     try:
         body = _fetch_measurement_body(report_id, input_, msmt_meta["measurement_uid"])
@@ -488,7 +489,7 @@ def get_measurement_meta() -> Response:
         log.error(e, exc_info=True)
         body = ""
 
-    return cachedjson("60s", raw_measurement=body, **msmt_meta)
+    return cachedjson("1m", raw_measurement=body, **msmt_meta)
 
 
 # # Listing measurements
@@ -1046,6 +1047,7 @@ def param_domain(name):
 
 
 def param_url(name):
+    """Accepts URLs, empty string or None"""
     p = request.args.get(name)
     if not p:
         return p

--- a/newapi/ooniapi/measurements.py
+++ b/newapi/ooniapi/measurements.py
@@ -1073,7 +1073,7 @@ def param_input_or_none() -> Optional[str]:
     if not p:
         return None
     x = p.encode("ascii", "ignore").decode()
-    accepted = string.ascii_letters + string.digits + r' :/.[]-_%+(){}=?#&!,'
+    accepted = string.ascii_letters + string.digits + r' :/.[]-_%+(){}=?#&!,$'
     for c in x:
         if c not in accepted:
             raise ValueError(f"Invalid characters in input field")

--- a/newapi/ooniapi/private.py
+++ b/newapi/ooniapi/private.py
@@ -321,8 +321,7 @@ def api_private_test_coverage() -> Response:
 
     tc = get_recent_test_coverage_ch(probe_cc)
     nc = get_recent_network_coverage_ch(probe_cc, test_groups)
-    # FIXME
-    return cachedjson("0s", network_coverage=nc, test_coverage=tc)
+    return cachedjson("1h", network_coverage=nc, test_coverage=tc)
 
 
 @api_private_blueprint.route("/website_networks", methods=["GET"])

--- a/newapi/ooniapi/probe_services.py
+++ b/newapi/ooniapi/probe_services.py
@@ -12,13 +12,13 @@ from hashlib import sha512
 from urllib.request import urlopen
 
 import ujson
-from flask import Blueprint, current_app, request, make_response, Response
+from flask import Blueprint, current_app, request, Response
 from flask.json import jsonify
 
 import jwt.exceptions  # debdeps: python3-jwt
 
 from ooniapi.config import metrics
-from ooniapi.utils import cachedjson, nocachejson
+from ooniapi.utils import cachedjson, nocachejson, jerror
 
 from ooniapi.auth import create_jwt, decode_jwt
 from ooniapi.prio import generate_test_list
@@ -626,10 +626,6 @@ def serve_tor_targets() -> Response:
 
 # Unneded: we use an external test helper
 # @probe_services_blueprint.route("/api/private/v1/wcth")
-
-
-def jerror(msg, code=400):
-    return make_response(jsonify(error=msg), code)
 
 
 @probe_services_blueprint.route("/invalidpath")

--- a/newapi/ooniapi/utils.py
+++ b/newapi/ooniapi/utils.py
@@ -1,4 +1,6 @@
+
 from datetime import datetime
+from flask import make_response, Response
 from flask.json import jsonify
 
 ISO_TIMESTAMP_SHORT = "%Y%m%dT%H%M%SZ"
@@ -7,7 +9,7 @@ OONI_EPOCH = datetime(2012, 12, 5)
 INTERVAL_UNITS = dict(s=1, m=60, h=3600, d=86400)
 
 
-def cachedjson(interval: str, *a, **kw):
+def cachedjson(interval: str, *a, **kw) -> Response:
     """Jsonify and add cache expiration"""
     resp = jsonify(*a, **kw)
     unit = interval[-1]
@@ -16,9 +18,15 @@ def cachedjson(interval: str, *a, **kw):
     return resp
 
 
-def nocachejson(*a, **kw):
+def nocachejson(*a, **kw) -> Response:
     """Jsonify and explicitely prevent caching"""
     resp = jsonify(*a, **kw)
     resp.cache_control.max_age = 0
+    resp.cache_control.no_cache = True
+    return resp
+
+
+def jerror(msg, code=400) -> Response:
+    resp = make_response(jsonify(error=msg), code)
     resp.cache_control.no_cache = True
     return resp

--- a/newapi/tests/conftest.py
+++ b/newapi/tests/conftest.py
@@ -82,9 +82,8 @@ def checkout_pipeline(tmpdir_factory):
     d = tmpdir_factory.mktemp("pipeline")
     if d.isdir():
         shutil.rmtree(d)
-    #cmd = f"git clone --depth 1 https://github.com/ooni/pipeline -q {d}"
-    # FIXME
-    cmd = f"git clone --depth 1 https://github.com/ooni/pipeline --branch reprocessor-ch -q {d}"
+    cmd = f"git clone --depth 1 https://github.com/ooni/pipeline -q {d}"
+    #cmd = f"git clone --depth 1 https://github.com/ooni/pipeline --branch reprocessor-ch -q {d}"
     print(cmd)
     cmd = cmd.split()
     subprocess.run(cmd, check=True, stdout=PIPE, stderr=PIPE).stdout

--- a/newapi/tests/integ/test_integration.py
+++ b/newapi/tests/integ/test_integration.py
@@ -852,7 +852,8 @@ def test_list_measurements_external_order_by(client):
 
 
 def test_list_measurements_bug_probe1034(client):
-    url = "measurements?report_id=blah"
+    rid = "20210709T004340Z_webconnectivity_MY_4818_n1_YCM7J9mGcEHds2K3"
+    url = f"measurements?report_id={rid}"
     r = client.get(f"/api/v1/{url}", headers={"user-agent": "okhttp"})
     assert r.status_code == 200
     assert r.is_json

--- a/newapi/tests/integ/test_params_validation.py
+++ b/newapi/tests/integ/test_params_validation.py
@@ -1,0 +1,36 @@
+import pytest
+
+from ooniapi import measurements as apimsm
+
+
+def test_param_report_id_missing(app):
+    params = {}
+    with app.test_request_context("/", query_string=params):
+        pytest.raises(Exception, apimsm.param_report_id)
+
+
+def test_param_report_id_valid(app):
+    rid = "20220816T111242Z_webconnectivity_IR_197207_n1_KJYYCOK8vwUiOBSe"
+    params = {"report_id": rid}
+    with app.test_request_context("/", query_string=params):
+        rid_x = apimsm.param_report_id()
+        assert rid == rid_x
+
+
+def test_param_report_id_invalid(app):
+    rid = "20220816T111242Z_webconnectivity_IR_197207_n1_KJYYCOK8vwUiOBSe+"
+    params = {"report_id": rid}
+    with app.test_request_context("/", query_string=params):
+        pytest.raises(Exception, apimsm.param_report_id)
+
+
+def test_param_url_empty(app):
+    params = {"input": ""}
+    with app.test_request_context("/", query_string=params):
+        assert apimsm.param_url("input") == ""
+
+
+def test_param_url_invalid(app):
+    params = {"input": "(-/"}
+    with app.test_request_context("/", query_string=params):
+        pytest.raises(Exception, apimsm.param_url)

--- a/newapi/tests/integ/test_params_validation.py
+++ b/newapi/tests/integ/test_params_validation.py
@@ -34,3 +34,35 @@ def test_param_url_invalid(app):
     params = {"input": "(-/"}
     with app.test_request_context("/", query_string=params):
         pytest.raises(Exception, apimsm.param_url)
+
+
+def test_param_input_or_none_invalid(app):
+    params = {"input": ""}
+    with app.test_request_context("/", query_string=params):
+        assert apimsm.param_input_or_none() is None
+
+    with app.test_request_context("/"):
+        assert apimsm.param_input_or_none() is None
+
+
+def test_param_input_or_none_valid(app):
+    valid_inputs = [
+        "https://foo.org",
+        "http://foo.org",
+        "dot://doh-de.blahdns.com/dns-query",
+        "dot://8.8.8.8:853/",
+        "dot://[2a00:5a60::ad2:0ff]:853",
+        "stun://stun.voip.blackberry.com:3478",
+        "obfs3 83.212.101.3:80",
+        "obfs3 83.212.101.3:80 A09D536DD1752D542E1FBB3C9CE4449D51298239",
+        "fte 50.7.176.114:80 2BD466989944867075E872310EBAD65BC88C8AEF",
+        "udp://8.8.8.8",
+        "scramblesuit 83.212.101.3:443",
+        "https://ru.wikipedia.org/wiki/Вторжение_России_на_Украину_(2022)",
+        "obfs4 154.35.22.9:80 C73AD cert=gEWN/bS",
+    ]
+    for inp in valid_inputs:
+        params = {"input": inp}
+        print(params)
+        with app.test_request_context("/", query_string=params):
+            assert apimsm.param_input_or_none() == inp


### PR DESCRIPTION
Also enable response caching.
Mitigate the impact of vulnerability scanners hitting the API.
