### PR TITLE
Remove Tor and Psiphon configs from check-in

### DIFF
--- a/newapi/debian/changelog
+++ b/newapi/debian/changelog
@@ -1,3 +1,9 @@
+ooni-api (1.0.38) unstable; urgency=medium
+
+  * Remove Tor and Psiphon confs from check-in
+
+ -- Federico Ceratto <federico@debian.org>  Wed, 18 Jan 2023 12:54:46 +0000
+
 ooni-api (1.0.37) unstable; urgency=medium
 
   * Add test-helpers data to check-in

--- a/newapi/ooniapi/probe_services.py
+++ b/newapi/ooniapi/probe_services.py
@@ -270,7 +270,7 @@ def check_in() -> Response:
         test_items = []
 
     metrics.gauge("check-in-test-list-count", len(test_items))
-    conf = dict(features={})
+    conf: Dict[str, Any] = dict(features={})
 
     # set webconnectivity_0.5 feature flag for some probes
     octect = extract_probe_ipaddr_octect(1, 0)

--- a/newapi/ooniapi/probe_services.py
+++ b/newapi/ooniapi/probe_services.py
@@ -201,10 +201,6 @@ def check_in() -> Response:
             conf:
               type: object
               description: auxiliary configuration parameters
-              psiphon:
-                type: object
-              tor:
-                type: object
               features:
                 type: object
                 description: feature flags
@@ -274,13 +270,7 @@ def check_in() -> Response:
         test_items = []
 
     metrics.gauge("check-in-test-list-count", len(test_items))
-    try:
-        torconf = _load_json(current_app.config["TOR_TARGETS_CONFFILE"])
-        psconf = _load_json(current_app.config["PSIPHON_CONFFILE"])
-        conf = dict(tor=torconf, psiphon=psconf, features={})
-    except Exception as e:
-        log.error(str(e), exc_info=True)
-        conf = dict(features={})
+    conf = dict(features={})
 
     # set webconnectivity_0.5 feature flag for some probes
     octect = extract_probe_ipaddr_octect(1, 0)

--- a/newapi/tests/integ/test_probe_services.py
+++ b/newapi/tests/integ/test_probe_services.py
@@ -115,8 +115,7 @@ def test_check_in_basic(client):
     assert stn == "webconnectivity"
     assert cc == "US"
 
-    # psiphon and tor configurations
-    assert sorted(c["conf"]) == ["features", "psiphon", "test_helpers", "tor"]
+    assert sorted(c["conf"]) == ["features", "test_helpers"]
 
 
 def test_check_in_url_category_news(client):


### PR DESCRIPTION
Implements the initial part of https://docs.google.com/document/d/1Nd-i_UsrfUVAiy_X5IdVFwFKpqL4xufasLqcuol8YJI/edit#heading=h.1etbyrl6nr4k