### PR TITLE
Fixed keys for user reporting mechanism

### DIFF
--- a/newapi/ooniapi/measurements.py
+++ b/newapi/ooniapi/measurements.py
@@ -1554,9 +1554,10 @@ valid_feedback_status = [
     "blocked.tcp",
     "blocked.tls",
     "ok",
-    "ok.unreachable",
-    "ok.broken",
-    "ok.parked",
+    "broken",
+    "broken.parked",
+    "broken.down",
+    "broken.other",
 ]
 
 

--- a/newapi/ooniapi/measurements.py
+++ b/newapi/ooniapi/measurements.py
@@ -1554,10 +1554,9 @@ valid_feedback_status = [
     "blocked.tcp",
     "blocked.tls",
     "ok",
-    "broken",
-    "broken.parked",
-    "broken.down",
-    "broken.other",
+    "down",
+    "down.unreachable",
+    "down.misconfigured"
 ]
 
 


### PR DESCRIPTION
The keys for the user reporting mechanism had the values `unreachable`, `broken` and `parked` nested under `ok` (which pertains to successful measurements), which is not accurate.

This PR removes the `unreachable` value (which generally qualifies under `blocked`, but we already have more specific values under `blocked`), and creates nested values (including `parked`) under `broken`. 